### PR TITLE
Add build smoke test to CI pipeline

### DIFF
--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -81,7 +81,20 @@ jobs:
         
     - name: Build Quarto book
       run: quarto render
-        
+
+    - name: Smoke test build output
+      run: |
+        echo "Checking index.html exists..."
+        test -f _book/index.html || { echo "FAIL: _book/index.html missing"; exit 1; }
+
+        echo "Checking converted days..."
+        for day in 01 02 03 04 05; do
+          ls _book/content/days/day-${day}/*.html > /dev/null 2>&1 || { echo "FAIL: No HTML files for day-${day}"; exit 1; }
+          echo "  day-${day}: OK"
+        done
+
+        echo "Smoke test passed"
+
     - name: Setup SSH
       run: |
         mkdir -p ~/.ssh

--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -82,13 +82,15 @@ jobs:
     - name: Build Quarto book
       run: quarto render
 
+    # Keep in sync with deploy.yml
     - name: Smoke test build output
       run: |
         echo "Checking index.html exists..."
         test -f _book/index.html || { echo "FAIL: _book/index.html missing"; exit 1; }
 
         echo "Checking converted days..."
-        for day in 01 02 03 04 05; do
+        for day_dir in content/days/day-*/; do
+          day=$(basename "$day_dir" | sed 's/day-//')
           ls _book/content/days/day-${day}/*.html > /dev/null 2>&1 || { echo "FAIL: No HTML files for day-${day}"; exit 1; }
           echo "  day-${day}: OK"
         done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,13 +111,18 @@ jobs:
         quarto render
         echo "Build completed successfully"
         
-    - name: Verify build output
+    - name: Smoke test build output
       run: |
-        if [ ! -d "_book" ]; then
-          echo "Error: _book directory not found after build"
-          exit 1
-        fi
-        echo "Build verification passed"
+        echo "Checking index.html exists..."
+        test -f _book/index.html || { echo "FAIL: _book/index.html missing"; exit 1; }
+
+        echo "Checking converted days..."
+        for day in 01 02 03 04 05; do
+          ls _book/content/days/day-${day}/*.html > /dev/null 2>&1 || { echo "FAIL: No HTML files for day-${day}"; exit 1; }
+          echo "  day-${day}: OK"
+        done
+
+        echo "Smoke test passed"
         
     - name: Setup SSH with key verification
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,13 +111,15 @@ jobs:
         quarto render
         echo "Build completed successfully"
         
+    # Keep in sync with deploy-optimized.yml
     - name: Smoke test build output
       run: |
         echo "Checking index.html exists..."
         test -f _book/index.html || { echo "FAIL: _book/index.html missing"; exit 1; }
 
         echo "Checking converted days..."
-        for day in 01 02 03 04 05; do
+        for day_dir in content/days/day-*/; do
+          day=$(basename "$day_dir" | sed 's/day-//')
           ls _book/content/days/day-${day}/*.html > /dev/null 2>&1 || { echo "FAIL: No HTML files for day-${day}"; exit 1; }
           echo "  day-${day}: OK"
         done


### PR DESCRIPTION
## Summary
- Adds a smoke test step between `quarto render` and `rsync` deploy in both `deploy.yml` and `deploy-optimized.yml`
- Verifies `_book/index.html` exists and all converted days (01-05) have HTML output
- Prevents incomplete builds from being deployed to production via `rsync --delete`

Closes #73

## Test plan
- [ ] Verify smoke test step appears in both workflow files
- [ ] Confirm the day list (01-05) matches currently converted days
- [ ] Trigger a deploy run and confirm the smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)