### PR TITLE
Add pre-deploy backup of production site

### DIFF
--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -108,6 +108,21 @@ jobs:
           exit 1
         fi
         
+    # Keep in sync with deploy.yml
+    - name: Backup current deployment
+      run: |
+        DEPLOY_PATH="www/deming.leedurbin.co.nz/public_html"
+        BACKUP_DIR="www/deming.leedurbin.co.nz/backups"
+        SSH_CMD="ssh -p 18765 u197-gmrgybn3hkn2@ssh.leedurbin.co.nz"
+
+        echo "Creating pre-deploy backup..."
+        $SSH_CMD "mkdir -p ${BACKUP_DIR} && cp -r ${DEPLOY_PATH} ${BACKUP_DIR}/public_html.backup.\$(date +%Y%m%d%H%M%S)"
+        echo "Backup created"
+
+        echo "Cleaning up old backups (keeping last 5)..."
+        $SSH_CMD "cd ${BACKUP_DIR} && ls -1d public_html.backup.* 2>/dev/null | sort | head -n -5 | xargs -r rm -rf"
+        echo "Backup cleanup complete"
+
     - name: Deploy to server
       run: |
         rsync -avz --delete -e "ssh -p 18765" _book/ u197-gmrgybn3hkn2@ssh.leedurbin.co.nz:www/deming.leedurbin.co.nz/public_html/

--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -116,12 +116,14 @@ jobs:
         SSH_CMD="ssh -p 18765 u197-gmrgybn3hkn2@ssh.leedurbin.co.nz"
 
         echo "Creating pre-deploy backup..."
-        $SSH_CMD "mkdir -p ${BACKUP_DIR} && cp -r ${DEPLOY_PATH} ${BACKUP_DIR}/public_html.backup.\$(date +%Y%m%d%H%M%S)"
-        echo "Backup created"
-
-        echo "Cleaning up old backups (keeping last 5)..."
-        $SSH_CMD "cd ${BACKUP_DIR} && ls -1d public_html.backup.* 2>/dev/null | sort | head -n -5 | xargs -r rm -rf"
-        echo "Backup cleanup complete"
+        $SSH_CMD "mkdir -p ${BACKUP_DIR} && \
+          if [ -d ${DEPLOY_PATH} ]; then \
+            cp -r ${DEPLOY_PATH} ${BACKUP_DIR}/public_html.backup.\$(date +%Y%m%d%H%M%S) && \
+            cd ${BACKUP_DIR} && ls -1d public_html.backup.* 2>/dev/null | sort | head -n -5 | xargs -r rm -rf; \
+          else \
+            echo 'No existing deployment found, skipping backup'; \
+          fi"
+        echo "Backup complete"
 
     - name: Deploy to server
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,12 +177,14 @@ jobs:
         SSH_CMD="ssh -p 18765 u197-gmrgybn3hkn2@ssh.leedurbin.co.nz"
 
         echo "Creating pre-deploy backup..."
-        $SSH_CMD "mkdir -p ${BACKUP_DIR} && cp -r ${DEPLOY_PATH} ${BACKUP_DIR}/public_html.backup.\$(date +%Y%m%d%H%M%S)"
-        echo "Backup created"
-
-        echo "Cleaning up old backups (keeping last 5)..."
-        $SSH_CMD "cd ${BACKUP_DIR} && ls -1d public_html.backup.* 2>/dev/null | sort | head -n -5 | xargs -r rm -rf"
-        echo "Backup cleanup complete"
+        $SSH_CMD "mkdir -p ${BACKUP_DIR} && \
+          if [ -d ${DEPLOY_PATH} ]; then \
+            cp -r ${DEPLOY_PATH} ${BACKUP_DIR}/public_html.backup.\$(date +%Y%m%d%H%M%S) && \
+            cd ${BACKUP_DIR} && ls -1d public_html.backup.* 2>/dev/null | sort | head -n -5 | xargs -r rm -rf; \
+          else \
+            echo 'No existing deployment found, skipping backup'; \
+          fi"
+        echo "Backup complete"
 
     - name: Deploy to server
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,6 +169,21 @@ jobs:
         fi
         echo "Host key added to known_hosts"
 
+    # Keep in sync with deploy-optimized.yml
+    - name: Backup current deployment
+      run: |
+        DEPLOY_PATH="www/deming.leedurbin.co.nz/public_html"
+        BACKUP_DIR="www/deming.leedurbin.co.nz/backups"
+        SSH_CMD="ssh -p 18765 u197-gmrgybn3hkn2@ssh.leedurbin.co.nz"
+
+        echo "Creating pre-deploy backup..."
+        $SSH_CMD "mkdir -p ${BACKUP_DIR} && cp -r ${DEPLOY_PATH} ${BACKUP_DIR}/public_html.backup.\$(date +%Y%m%d%H%M%S)"
+        echo "Backup created"
+
+        echo "Cleaning up old backups (keeping last 5)..."
+        $SSH_CMD "cd ${BACKUP_DIR} && ls -1d public_html.backup.* 2>/dev/null | sort | head -n -5 | xargs -r rm -rf"
+        echo "Backup cleanup complete"
+
     - name: Deploy to server
       run: |
         set -e


### PR DESCRIPTION
## Summary
- Adds a timestamped server-side backup step before each `rsync --delete` deployment, preventing data loss from bad deploys
- Automatically cleans up old backups, keeping only the last 5
- Added to both `deploy.yml` and `deploy-optimized.yml` with cross-reference comments

Closes #78

## Test plan
- [ ] Trigger a deploy and verify a backup directory appears at `www/deming.leedurbin.co.nz/backups/`
- [ ] Trigger 6+ deploys and verify only the 5 most recent backups are retained
- [ ] Verify the deployed site works correctly after the backup step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)