### PR TITLE
Remove dead .grid-mid CSS selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ issues/
 
 /scripts/
 **/*.quarto_ipynb
+
+docs/context/analysis/

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -183,61 +183,6 @@ Usage:
   text-align: center;
 }
 
-/* ===== GRID TABLE MOSAIC FOR GT TABLES AND ARROWS ===== */
-/* the 3×3 grid: table → arrow → table, repeated in 5 rows (3 table rows + 2 quote rows) */
-.grid-mid {
-  display: grid;
-  grid-template-columns: auto auto auto;
-  grid-template-rows: 
-    auto   /* row 1: tables */
-    auto   /* row 2: quotes + ↓ */
-    auto   /* row 3: tables */
-    auto   /* row 4: quotes + ↓ */
-    auto;  /* row 5: tables */;
-  column-gap: 1.5rem;
-  row-gap: 0.75rem;
-  align-items: center;
-  justify-content: center;
-}
-
-/* horizontal arrows between tables */
-.grid-mid .arrow-h {
-  grid-column: 2;
-  font-size: 2rem;
-  justify-self: center;
-}
-
-/* vertical arrows between quote rows */
-.grid-mid .arrow-v {
-  grid-column: 2;
-  font-size: 2rem;
-  justify-self: center;
-}
-
-/* left-aligned quote under each table-row */
-.grid-mid .quote-left {
-  font-style: italic;
-  color: #0000b3;
-  font-size: 0.9rem;
-  grid-column: 1;
-  justify-self: start;
-}
-
-/* right-aligned quote under each table-row */
-.grid-mid .quote-right {
-  font-style: italic;
-  color: #0000b3;
-  font-size: 0.9rem;
-  grid-column: 3;
-  justify-self: start;  /* or end, if you prefer */
-}
-
-/* tighten up GT tables themselves */
-.grid-mid table {
-  margin: 0; 
-  padding: 0;
-}
-
 /* ===== RESPONSIVE DESIGN ===== */
 
 /* Mobile styles (max-width: 768px) */


### PR DESCRIPTION
## Summary

- Removed the unused `.grid-mid` grid system and its 5 child selectors (55 lines) from `main.css`
- Verified the other two selectors flagged in #81 (`.foreman-remark`, `.analysis_box_title`) are actively used across multiple content files — retained them
- Also includes a minor `.gitignore` update

Closes #81

## Test plan

- [x] Grepped all `.qmd`, `.js`, and `.html` files to confirm `.grid-mid` has zero references
- [x] Confirmed `.foreman-remark` (50 uses across 24 files) and `.analysis_box_title` (1 use) are active
- [x] `quarto render` succeeds
- [x] No visual regressions (removed CSS was never rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)