### PR TITLE
Fix heading hierarchy across Days 1-4

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -123,7 +123,7 @@ Usage:
   margin: 20px;
 }
 
-.technical_aid h1, .technical_aid h2 {
+.technical_aid h1, .technical_aid h2, .technical_aid h3 {
   color: #000000;
   text-align: center;
 }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -92,7 +92,7 @@ Usage:
   margin: 20px;
 }
 
-.thought h1 {
+.thought h2 {
   color: #006600;
   text-align: center;
 }
@@ -103,7 +103,7 @@ Usage:
   margin: 20px;
 }
 
-.thought_commentary h1 {
+.thought_commentary h2 {
   color: #cc0000;
   text-align: center;
 }
@@ -172,7 +172,7 @@ Usage:
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
 }
 
-.major_activity_title h1 {
+.major_activity_title h2 {
   margin: 2px 0;
   padding: 10px 30px 10px 45px;
   border: 0;
@@ -253,7 +253,7 @@ Usage:
     border-radius: 20px;
   }
   
-  .major_activity_title h1 {
+  .major_activity_title h2 {
     font-size: 20px;
     padding: 12px 20px;
   }
@@ -287,7 +287,7 @@ Usage:
     padding: 10px;
   }
   
-  .major_activity_title h1 {
+  .major_activity_title h2 {
     font-size: 22px;
     padding: 12px 25px;
   }

--- a/content/days/day-01/02-rediscovered.qmd
+++ b/content/days/day-01/02-rediscovered.qmd
@@ -11,7 +11,7 @@ source(here::here("R/functions/main-functions.R"))
 ```
 
 
-# The Deming Prize and the Nashua Corporation {#sec-page2}
+## The Deming Prize and the Nashua Corporation {#sec-page2}
 
 :::: {.columns}
 
@@ -103,7 +103,7 @@ same as what most people mean by “flowcharting”.
   
 ::::
   
-# The four-day seminars
+## The four-day seminars
   
   I had no communication with Dr Deming himself during that time. I did, of course, hear more and more
 about him. One of the things I heard was that the people at Nashua Corporation had encouraged him to
@@ -148,7 +148,7 @@ create_clock(9, 40)
   
 ::::
   
-# The British Deming Association and later {#sec-page6}
+## The British Deming Association and later {#sec-page6}
   
   Not surprisingly, I soon began to present my own seminars on Dr Deming’s work and, largely with the help
 of people that I met at those early seminars and at the London four-day seminars, encouraged the formation of the British Deming Association in 1987. The BDA was a not-for-profit educational organisation having the aims of spreading awareness and aiding understanding of the Deming management philosophy.

--- a/content/days/day-01/03-statistics.qmd
+++ b/content/days/day-01/03-statistics.qmd
@@ -10,7 +10,7 @@ knitr::knit_hooks$set(crop = knitr::hook_pdfcrop)
 source(here::here("R/functions/main-functions.R"))
 ```
 
-# Statistics?
+## Statistics?
 
 Now, depending on your background, one feature of the previous section may have already started making
 you feel a little queasy. And that is the repeated references to things *statistical*. You know that Dr Deming
@@ -120,7 +120,7 @@ create_clock(9, 55)
 
 ::::
 
-# The two paradoxes
+## The two paradoxes
 
 So, as implied by that quote from *EST* and earlier, the truth is that the statistical tool which had pride of
 place in Dr Deming’s teaching is rarely to be seen in introductory courses on Statistics—nor, for that matter,
@@ -195,7 +195,7 @@ create_clock(10, 00)
 
 ::::
 
-# Control charts in this course
+## Control charts in this course
 
 So what does all this imply about my approach to control charts in this course? As in Dr Deming’s seminars, you will not have to construct any control charts if you’d prefer not to. However, you will see some
 control charts on Days 2 and 3, and so I shall include some relevant description there. But there is already

--- a/content/days/day-01/04-resources.qmd
+++ b/content/days/day-01/04-resources.qmd
@@ -14,7 +14,7 @@ In that optional excursion into the Appendix to discuss the first paradox, I inc
 this is an opportune time for me to also suggest some further reading along with video material which could
 be helpful in your learning about the more general main themes and content of this course.
 
-# The Deming Dimension
+## The Deming Dimension
 
 There is some detailed information about *The Deming Dimension* on [pages 12–13](index.qmd#sec-page12) of the Welcome section
 in the “A. PLEASE START HERE” file.
@@ -34,7 +34,7 @@ access to a library which could obtain such items for you to borrow, I’ll brie
 possibilities over the next couple of pages. There is detailed information on everything mentioned here and
 later in the “R. References and Sources” file.
 
-# Other books
+## Other books
 
 As far as other books are concerned, I must of course begin with Dr Deming’s own famous *Out of the Crisis*
 (1986) and *The New Economics for Industry, Government, Education* (first published in 1993). However,
@@ -98,7 +98,7 @@ more enjoyable read and a much greater help to your learning than previously. Th
 fortunate as to know and work with Dr Deming can still hear him speaking the words in this book: for those
 not so fortunate, *The Essential Deming* is a superb substitute.
 
-# Videos {#sec-page13}
+## Videos {#sec-page13}
 
 Regarding videos, there were two quite well-known short British-made TV documentaries: *Doctor’s Orders*
 (produced by Central ITV in 1988) and *A Prophet Unheard* (from the BBC in 1992). I often used part of
@@ -126,7 +126,7 @@ distributors, the former from the Deming Institute (see [page 4](#sec-page6)) an
 As you’d expect from the quantity concerned, the *Deming Library* would burn rather a hole in your pocket
 but *The Deming of America* is not overly expensive for this excellent hour-long programme.
 
-# And finally...
+## And finally...
 
 :::: {.columns}
 

--- a/content/days/day-01/07-quality-theory.qmd
+++ b/content/days/day-01/07-quality-theory.qmd
@@ -41,7 +41,7 @@ what the “request for action” is asking you to do. Preferably cover it up wi
 ::: {.column width="85%"}
 <div class=thought_commentary>
 
-# PAUSE FOR THOUGHT 1-a
+## PAUSE FOR THOUGHT 1-a
 
 <span class=deming_quote>“Quality is made at the top.”</span> Do you agree, and why?
 
@@ -83,7 +83,7 @@ And then, as a case in point, Dr Deming’s third and final mention of “qualit
 ::: {.column width="85%"}
 
 <div class=thought>
-# PAUSE FOR THOUGHT 1-b
+## PAUSE FOR THOUGHT 1-b
 
 Why do you think Dr Deming said that, if you manage by results, both quality and morale go down?
 
@@ -109,7 +109,7 @@ create_clock(11, 20)
 
 ::: {.column width="85%"}
 <div class=thought>
-# PAUSE FOR THOUGHT 1–c
+## PAUSE FOR THOUGHT 1–c
 
 I well remember a time that I met up with an old acquaintance. I hadn’t seen him for a while, so he
 didn’t know of my change in career and interests (and university)—he thought I still lectured in Mathematical Statistics somewhere else. “So what Department are you in, here at this university?”, he asked.

--- a/content/days/day-01/08-attraction.qmd
+++ b/content/days/day-01/08-attraction.qmd
@@ -71,7 +71,7 @@ that my preference lies toward the former of those two extremes!</div>
 
 ::: {.column width="85%"}
 <div class=thought>
-# ACTIVITY 1-d
+## ACTIVITY 1-d
 
 Considering the breadth indicated in the title of Dr Deming’s final book: *The New Economics for Industry, Government, Education*, it will be worthwhile for you to spend a little time thinking about the ways
 that the Government and Education systems in your country help or hinder Industry, and the quality of
@@ -104,7 +104,7 @@ create_clock(12, 00)
 
 ::: {.column width="85%"}
 <div class=thought>
-# PAUSE FOR THOUGHT 1–e
+## PAUSE FOR THOUGHT 1–e
 
 <div class=neave_note>This is today’s final Pause for Thought and it goes to the opposite extreme compared with the previous Activity. Here I’m just asking you to consider briefly something very simple in preparation for discussion tomorrow. No calculations, no deep thought—just quickly jot down a couple of opinions for
 future reference.</div>

--- a/content/days/day-01/09-different.qmd
+++ b/content/days/day-01/09-different.qmd
@@ -14,7 +14,7 @@ source(here::here("R/functions/main-functions.R"))
 As I hope you may already have begun to appreciate, the Deming philosophy is different, and not just a little different, from what we hear elsewhere about management and quality and work and business—and
 people. And yet, as I hope you’ll also increasingly appreciate as we work through this course, it has a persuasive and inevitable logic about it.
 
-# How different?
+## How different?
 
 If you are still not persuaded that it’s *that* different, I think you will be after this couple of pages. I’m now
 going to throw at you a whole heap of “bits and pieces”—lots of themes for the Overture, with very little
@@ -49,7 +49,7 @@ but with enabling good *understanding* on the part of everyone involved as to *w
 way of doing things. And I do mean “best”: I have already pointed out his fondness for the phrase
 <span class=deming_quote>“optimisation of the system”</span>—and “optimum” is Latin for “best”.
 
-# So what kind of environment is this Deming “optimum” system?
+## So what kind of environment is this Deming “optimum” system?
 
 * It’s certainly one in which far greater respect is paid to what psychologists call “intrinsic” motivation, as opposed to “extrinsic” motivation which is sadly far more familiar in modern management
 and government.

--- a/content/days/day-01/11-deming-story.qmd
+++ b/content/days/day-01/11-deming-story.qmd
@@ -10,7 +10,7 @@ knitr::knit_hooks$set(crop = knitr::hook_pdfcrop)
 source(here::here("R/functions/main-functions.R"))
 ```
 
-# Early 1900s: The story begins
+## Early 1900s: The story begins
 
 :::: {.columns}
 
@@ -34,7 +34,7 @@ Mathematics and teaching Engineering. He was then invited to teach at the Colora
 obtained a Master’s degree in Mathematics and Physics from the University of Colorado in 1924. He
 gained his doctorate in Mathematical Physics from Yale in 1928.
 
-# The 1920s: New statistics in manufacturing
+## The 1920s: New statistics in manufacturing
 
 I have mentioned the 1920s several times during the Overture, and so you know what’s coming here. Yes:
   Dr Walter Shewhart at the Western Electric Company, and understanding variation. How did Deming get
@@ -117,7 +117,7 @@ create_clock(1, 40)
 
 ::::
 
-# Shewhart’s breakthrough
+## Shewhart’s breakthrough
 
 Earlier I described Shewhart’s work in the 1920s as a “crucially important breakthrough” in understanding
 variation. It would be unfair of me to express it in such radiant terms without providing you with a more
@@ -198,7 +198,7 @@ create_clock(2, 20)
 
 ::::
 
-# 1930s–1940s: New statistics in non-manufacturing
+## 1930s–1940s: New statistics in non-manufacturing
 
 So it did all start with some new statistical thinking and methods in a manufacturing context. Regrettably, a
 few generations later, some people still seem to think that was all Dr Deming’s work was about, and all that
@@ -210,7 +210,7 @@ work there, particularly with the 1940 American Census, turned out to be supreme
 in this capacity that he first attracted some international attention. In fact his first visit to Japan, soon after
 the end of the Second World War, was primarily to work with the Japanese Census.
 
-# 1950s–1960s: <span class=deming_quote>“The theory of a system, and cooperation”</span>
+## 1950s–1960s: <span class=deming_quote>”The theory of a system, and cooperation”</span>
 
 Does that heading seem familiar? I’ll remind you a little later of where you first saw it.
 
@@ -273,7 +273,7 @@ create_clock(2, 30)
 
 ::::
 
-# <span class=deming_quote>A Summary of Teachings to Top Management and to Engineers in Japan</span>
+## <span class=deming_quote>A Summary of Teachings to Top Management and to Engineers in Japan</span>
 
 <span class=deming_quote>
 1. The flow diagram shown here was on the blackboard at every conference with top management:
@@ -383,7 +383,7 @@ industrial rebirth and its worldwide success to W Edwards Deming.”
 Some of the matters raised in Deming’s <span class=deming_quote>“Summary of Teachings”</span> will be seen to have parallels in the Major
 Activity at the end of this afternoon. Before that, let’s continue with the story. But to where?
 
-# The 1970s: The wasted years
+## The 1970s: The wasted years
 
 I well remember the occasion when I was one of a group of some 50 people enjoying a study weekend with
 Dr Deming at the Ashridge Management College in the UK, immediately following his London four-day
@@ -417,7 +417,7 @@ create_clock(2, 50)
 
 ::::
 
-# The 1980s (first half): The West awakens {#sec-page37}
+## The 1980s (first half): The West awakens {#sec-page37}
 
 Dr Deming’s involvement with the Nashua Corporation began just early enough to become known to the
 NBC television producer, Clare Crawford-Mason, in time for her to include in the documentary *If Japan Can, Why Can’t We?*, first screened in June 1980. That was the breakthrough in the West (almost exactly
@@ -474,7 +474,7 @@ And a lot of them didn’t want it to end. Initial thoughts of the need to form 
 
 The content of the four-day seminars in the mid-1980s is well reflected in *Out of the Crisis*: with particularly long and deep discussion of the 14 Points and the “Deadly Diseases” of Western management (to be studied here on Days 4 and 5), along with the Experiment on Red Beads (Day 2) and later also the Funnel Experiment (Day 3), and a wide selection of other topics from later in his book.
 
-# The 1980s (second half): A new climate
+## The 1980s (second half): A new climate
 
 But, by the late 1980s, Dr Deming’s teaching had broadened and deepened. The phrase “A New Climate” repeatedly came into my mind. Just as in Japan more than 35 years earlier, he was now strongly emphasising <span class=deming_quote>“Cooperation: Win-Win”</span> (I suspect that it may have been he who coined this now-well-known phrase)—not cooperation for some altruistic, magnanimous purpose but simply so that all concerned could gain, could be better off in all respects than if they carried on in the familiar old mode of conflict and destructive competition.
 
@@ -495,7 +495,7 @@ unconsciously, he surely knew he must try to develop something that would help t
 to better understand and continue to benefit from his life’s work. It was toward the end of 1989 that we
 first heard what is surely an extraordinary phrase:
 
-# 1990–1993: <span class=deming_quote>A System of Profound Knowledge</span>
+## 1990–1993: <span class=deming_quote>A System of Profound Knowledge</span>
 
 Extraordinary, yes—yet valid. This was his attempt, sometimes with the wisdom of hindsight, to summarise
 the core, the guts, the essence of his whole life’s work. His work *is* to do with knowledge, understanding,
@@ -617,7 +617,7 @@ quarter of a million people attended his celebrated four-day seminars between 19
 
 But what of...
 
-# 1994 and onward: The future
+## 1994 and onward: The future
 
 Here I can do no better than largely repeat the closing words of my Preface to the Third Printing of *DemDim*
 in 1998:

--- a/content/days/day-02/01-run-charts.qmd
+++ b/content/days/day-02/01-run-charts.qmd
@@ -149,7 +149,7 @@ Now, I repeat that this was just a simple introductory example, purely for illus
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 2–a
+## PAUSE FOR THOUGHT 2–a
 
 Even though these were not real sales figures, and this was not a real management team, do you think that this was a reasonable account of how management might have reacted had these been real sales data?
 

--- a/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
+++ b/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
@@ -44,7 +44,7 @@ Now, before we get into the details of the Red Beads Experiment, I'll ask you to
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 2–b
+## PAUSE FOR THOUGHT 2–b
 
 As we grow older, and hopefully wiser, we may think about several things quite differently from the way
 that we used to. So identify something that you now regard very differently from the way that you did
@@ -85,7 +85,7 @@ Your answer to the first of the questions in Pause for Thought 2–b was surely 
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 2–c
+## PAUSE FOR THOUGHT 2–c
 
 What are some ways we can acquire and suffer from “illusion of knowledge”?
 

--- a/content/days/day-02/03-a-brief-overview.qmd
+++ b/content/days/day-02/03-a-brief-overview.qmd
@@ -48,7 +48,7 @@ The results produced when the experiment was performed at that company in Irelan
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 2–d
+## PAUSE FOR THOUGHT 2–d
 
 Take a careful look through these results. What main feature occurs to you when comparing the six Willing Workers with each other?
 

--- a/content/days/day-02/04-our-first-control-chart.qmd
+++ b/content/days/day-02/04-our-first-control-chart.qmd
@@ -61,7 +61,7 @@ As a new user of the control chart, here is your obvious Pause for Thought:
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 2–e
+## PAUSE FOR THOUGHT 2–e
 What does the above control chart tell you?
 
 ```{ojs}

--- a/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
+++ b/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
@@ -30,7 +30,7 @@ Going by what they see, the delegates will more naturally identify with the "All
 :::
 ::::
 
-# The training, part 1
+## The training, part 1
 
 Of the two personalities mentioned above, the Foreman is in the "Un-Knowing" state—although he does not appear to appreciate the fact! In the context of this experiment, that is indeed the more realistic part for him to play. For who *really* fully understands the processes and systems for which they bear responsibility?
 
@@ -44,7 +44,7 @@ As mentioned earlier, the work standard is 50 items of production per worker per
 
 Before each worker performs the task, a mixing operation is to be carried out, and so this is now demonstrated by the Foreman. It consists of tipping all the beads from the container into the bucket and then back into the container. (The system uses gravity—fortunately a cheap and plentiful resource.) The worker (or, during the demonstration, the Foreman) takes the paddle and places it on the edge of the container, holding it at a specified angle of 44° to the horizontal. The paddle is then gently but firmly pushed into the beads, with its slope allowed to steadily decrease to nearly horizontal. Great care must be exercised during this procedure. The 50 depressions will now be entirely covered by the beads. The paddle should next be raised back to that same angle of 44° with the horizontal. Then, retaining that angle, the paddle is drawn out from the beads. 50 beads will have been caught in the holes in the paddle. There may be some surplus beads sitting on top of the paddle; if so, they must be shaken off by gently tapping the paddle against the sides of the container. It is vital that the paddle be raised to 44° *before* withdrawing it from the beads—for otherwise there may soon be some beads rolling around the table and onto the floor.
 
-# The training, part 2
+## The training, part 2
 
 The 50 beads are the workers' production for that week, the white and red beads being good and bad product respectively. Having demonstrated the operation himself, the Foreman takes the paddle over to the workers to show them what he has produced. He points out his large majority of white product, and also states that he has included just a few defective red product so that they can see and be clear about what they need to avoid making.
 
@@ -56,7 +56,7 @@ Now that both the inspectors and the workers have received their training, we ar
 
 Oh, and finally, he wishes them good luck and trusts that they will enjoy their work!
 
-# The "real work"
+## The "real work"
 
 And so the real work commences. The workers come forward, one by one, to carry out their task under the watchful eye of the Foreman. He looks out for things to criticise. The initial angle may be wrong; the action may be jerky, or too fast, or too slow; the paddle may be lowered at the wrong rate; the paddle may not be inserted far enough into the container; the withdrawal angle may be wrong; instead of "gently tapping" the paddle to get rid of any surplus beads, the action may be too rough; the worker might try to tip the paddle, or shake it up and down rather than side to side. Of course, if the worker produces very few red beads, perhaps even meeting the quota of five or less, the Foreman instead congratulates the worker's care, concentration and obedience to the details of the procedure.
 
@@ -70,12 +70,12 @@ We have already seen on page 15 the control chart for the results recorded by De
 
 So let us summarise. If the control chart of data from the experiment indicates that the process is in statistical control then this tells us that effectively all of the variation is coming from the *system*—with the Willing Workers being at the mercy of that system. When they carry out their task, the fact is that whether they get a good result or a bad result is merely a matter of *luck*. Should we praise them for simply being lucky? Should we criticise them for being unlucky? What use could it be to appraise their performance when the variation comes from the *system*? None. How could it be justified? It cannot.
 
-# The Technical Aids
+## The Technical Aids
 
 <span class="neave_note"><p>We have now reached the first of the Technical Aids to be included in Days 2 and 3. Here, Technical Aids 1 and 2 describe how the control limits are computed for control charts that are based on the type of data produced and recorded in Red Beads Experiments. Technical Aid 3 contains a warning that, although control limits for all kinds of data are based on similar reasoning, some of the fine detail will vary according to the particular type of data being recorded. Hence the method described here is *not* generally applicable to many other types of data. This matter will be pursued on Day 3.</p> <p>Let me remind you that those who have opted for Stats-level 0 are invited to skip the Technical Aids! Thus, if you have elected to be on Stats-level 0 (or 00), please now move straight on to page 22.</p></span>
 
 <div class="technical_aid">
-## Technical Aid 1
+### Technical Aid 1
 
 One of the earliest applications of Shewhart's invention of the control chart was for batch inspection of mass production processes. In such inspection, samples (batches) of $n$ items from the process's output are regularly drawn and inspected, and the number $X$ of defective items recorded. After several samples have been inspected, the control limits are computed as follows.
 
@@ -112,7 +112,7 @@ Space has also been left for these computations at the top of Workbook page 14.
 </iframe>
 
 <div class="technical_aid">
-## Technical Aid 2
+### Technical Aid 2
 
 Firstly, notice that Dec recorded the total number of red beads obtained in the experiment near the bottom right of his table on page 11: it was 235. But now you'll need your calculator.
 
@@ -126,7 +126,7 @@ Finally, the distance from $\overline{X}$ out to the two control limits is $3\sq
 </div>
 
 <div class="technical_aid">
-## Technical Aid 3
+### Technical Aid 3
 
 If during Day 1 you read the discussion in the Appendix about the first paradox then you may recall Dr Deming's mention of Shewhart's "3σ-limits" (σ is a Greek letter, pronounced "sigma"). The control limits that you have just computed follow Shewhart's guidance by using $\sigma = \sqrt{\overline{X}(1-\overline{p})}$. The reason for this particular choice when the data come from batch inspection as in the Red Beads Experiment will, I'm afraid, have to be reserved for pages 85–88 in the Optional Extras section.
 

--- a/content/days/day-02/06-your-turn.qmd
+++ b/content/days/day-02/06-your-turn.qmd
@@ -19,7 +19,7 @@ Now comes the time for you to get some practice at playing the role of the Forem
 
 <div class="thought_commentary">
 
-# ACTIVITY 2–f
+## ACTIVITY 2–f
 
 The next four pages show you, one at a time, the results from the Red Beads Experiment illustrated in *DemDim* Chapter 6.
 

--- a/content/days/day-02/07-some-recollections.qmd
+++ b/content/days/day-02/07-some-recollections.qmd
@@ -63,7 +63,7 @@ There will then remain just two further items on today's agenda. First comes the
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 2–e
+## PAUSE FOR THOUGHT 2–e
 
 As you will see, I have reproduced for you below and on the next page the statisticians' data week by
 week. There is space on the right of the data for your Foreman-like comments on every count of red

--- a/content/days/day-03/01-variation-the-enemy-of-quality.qmd
+++ b/content/days/day-03/01-variation-the-enemy-of-quality.qmd
@@ -51,7 +51,7 @@ Unexpected as it might be, it seems that Dr Deming first used the terms "common 
 
 <div class="thought_commentary">
 
-# ACTIVITY 3–a
+## ACTIVITY 3–a
 
 Suggest some of the possible causes of variation in the arrival-time of my school bus.
 
@@ -78,7 +78,7 @@ Being guided by the thoughts about prison riots, factors which result in somewha
 
 <div class="thought">
 
-# ACTIVITY 3–b
+## ACTIVITY 3–b
 
 There is a saying that "Variety is the spice of life". This implies that *variety* is good. In these early pages of Day 3, we (and Dr Deming!) have been arguing that *variation* is bad.
 

--- a/content/days/day-03/02-at-the-ford-motor-company.qmd
+++ b/content/days/day-03/02-at-the-ford-motor-company.qmd
@@ -27,7 +27,7 @@ Reduced variation! Better quality! Everything clearly within the specifications!
 
 <div class="thought">
 
-# ACTIVITY 3–c
+## ACTIVITY 3–c
 
 To repeat:
 

--- a/content/days/day-03/03-the-importance-of-time.qmd
+++ b/content/days/day-03/03-the-importance-of-time.qmd
@@ -23,7 +23,7 @@ Here are two forms of histogram of those data. On the left, each item in the dat
 
 <div class="thought_commentary">
 
-# ACTIVITY 3–d
+## ACTIVITY 3–d
 
 Here is another sequence of 24 numbers. Please sketch a histogram of these data. I suggest you use separate boxes as on the left above. What do you conclude?
 
@@ -52,7 +52,7 @@ Just to be sure, let's draw run charts of the data. Here is a run chart for the 
 
 <div class="thought_commentary">
 
-# ACTIVITY 3–e
+## ACTIVITY 3–e
 
 Here again are the data from the second process (to save you from having to look back):
 

--- a/content/days/day-03/04-more-on-the-sales-data.qmd
+++ b/content/days/day-03/04-more-on-the-sales-data.qmd
@@ -33,7 +33,7 @@ First, a short Pause for Thought:
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 3–f
+## PAUSE FOR THOUGHT 3–f
 
 Does the Ford example from earlier today (pages 5–6) suggest to you any concerns about the management's interpretation of yesterday's monthly sales data (Day 2 pages 1–3), the conclusions they drew, and the decisions they made?
 

--- a/content/days/day-03/05-how-do-we-compute-control-limits.qmd
+++ b/content/days/day-03/05-how-do-we-compute-control-limits.qmd
@@ -135,7 +135,7 @@ This was clearly a case where, in practice, there was little to be gained by pro
 
 <div class="thought">
 
-# ACTIVITY 3–g
+## ACTIVITY 3–g
 
 Just for practice, compute the control limits by the method just demonstrated (again using just the first 12 values) on the data whose run chart you drew in Activity 3–e on page 8. Here are those data:
 

--- a/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
+++ b/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
@@ -14,7 +14,7 @@ source(here::here("R/functions/main-functions.R"))
 *Relevant sections of this Major Activity are also in the Workbook: I'll give you the page references where and when appropriate*
 
 <div class="major_activity_title">
-<h1>MAJOR ACTIVITY 3–h</h1>
+<h2>MAJOR ACTIVITY 3–h</h2>
 </div>
 
 Before we begin, a few words about the nature and purpose of the Funnel Experiment, some of which you will recognise as having been just as relevant to the Red Beads Experiment. As there, sooner or later it will become obvious to you that some of the strategies used and actions carried out are, depending on the circumstances, rather foolish! But that is precisely what's intended. Both experiments are very simple—so simple that the difference between good and bad practice becomes plain for all to see. However, after the Funnel Experiment had been presented, both Dr Deming in his enormous seminars and I in my smaller-scale ones would then ask the delegates to tell us of examples of what had now become clear to them as costly and damaging bad practices in their own lives, their own experience, their own workplaces, their own organisations. And invariably the delegates would come up with *dozens* of such real-world examples analogous to the bad practices of which they were now aware through what they had just learned from the Funnel Experiment. Often they had carried out such practices themselves—not because they were bad people but because they hadn't previously *realised* that the practices were so bad. Now they did. Thus, as with the Red Beads Experiment, the purpose of the Funnel Experiment is to alert you to the truth of such matters, so that in future you will be able to figure out more successfully what is good practice and what is not: what to do and what to avoid. As you go through the experiment, when similarly you think of practical examples in your own experience of what the Funnel Experiment is teaching, make a note of them since they will be of help when you get to today's Final Activity.
@@ -23,7 +23,7 @@ It is easy to think of real-life illustrations of the Funnel Experiment in many 
 
 With reference to the two illustrations just mentioned, the numbers on the funnel's and marble's tracks can relate to *minutes* in the case of the bus arrival time and *tenths of a millimetre* for the width of the socket. So the "target" of either 8.30 am or 2.30 cm is represented by 30 on the track, while the 29 refers to 8.29 am or 2.29 cm, 31 to 8.31 am or 2.31 cm, 34 to 8.34 am or 2.34 cm, etc.
 
-### The First Two Rules of the Funnel
+## The First Two Rules of the Funnel
 
 An obvious way to attempt to improve results from a process is to compare the current outcome (today's bus arrival time or the width of the socket just manufactured) with the nominal or target value, a comparison which may suggest a *try* to improve the next outcome. In our "flattened" version of the Funnel Experiment, this adjustment will be represented in what follows by the movement of our funnel along its track—to the *left* if we want to try to make the next outcome respectively *earlier* or *smaller*, or to the *right* if we want to make it *later* or *larger*. Thus, if the bus arrives today at 8.33 (three minutes late), perhaps the bus driver should set out three minutes earlier tomorrow. (I am assuming that my uncle is keen to please me rather than anybody else!) Or, if the socket just made measures 2.33 cm (0.03 cm too wide), we can adjust a control on the machine to reduce the average diameter of future sockets by 0.03 cm. In either case, the equivalent movement of our funnel is a distance of 3 squares (minutes or tenths of a millimetre, etc—whatever units we are using) to the left along its track. Thus we compensate for the amount that the current outcome is off-target by moving the funnel by that same amount in the opposite direction. This type of compensation strategy is in fact the second of what both Drs Nelson and Deming referred to as the four Rules of the Funnel. Here we are demonstrating it first because it corresponds to what was happening first in the Ford example on page 5. We shall introduce the other three Rules in due course.
 
@@ -35,7 +35,7 @@ In this digital version, the dice are rolled for you automatically. The <span cl
 
 In this example, since of course the preferred outcome is always that target of 30 (corresponding to the bus arriving at 8.30 or to a socket diameter of 2.30 cm), you may as well start by putting the funnel at what would appear to be the "obvious" position, i.e. 30.
 
-### Rule 2 of the Funnel (Ford's First Strategy)
+## Rule 2 of the Funnel (Ford's First Strategy)
 
 A particularly appealing way of considering this strategy (i.e. Rule 2 of the Funnel) is that it tells you to move the funnel to the position (27) where, if only it had been there when the marble was just dropped through it, you *would have* just obtained the preferred target outcome of 30. With the funnel placed there, the dice-score of 10 led you to move the marble 3 squares to the right of the funnel; so you would then have had the marble at the target, 30.
 
@@ -176,7 +176,7 @@ Finally, summarise the outcomes that you've just generated in a histogram. The "
 
 <div class="separator_blue"></div>
 
-### Rule 1 of the Funnel (Ford's Second Strategy)
+## Rule 1 of the Funnel (Ford's Second Strategy)
 
 I'll postpone discussion on the outcomes from this strategy (which you'll recall is what Drs Nelson and Deming called Rule 2 of the Funnel) until you've repeated the whole exercise using an easier strategy.
 
@@ -290,7 +290,7 @@ So now summarise your new data in a histogram as before.
 }
 ```
 
-### Discussion
+## Discussion
 
 Compare the two histograms you've drawn on pages 45 and above *[WB 39 and 41]*. As you'll probably have realised already, the histogram that you've just constructed is somewhat more tightly clustered around the desired value of 30 than the previous one was. The difference may not be dramatic, but it's certainly there. So this process performs better than the previous one: there is less variation. Yet this process was the "lazy" one. It is much less complicated, much quicker and easier to operate. With this strategy (Rule 1) we haven't "tweaked" the process at all. We've put in less effort—and got better performance! With Ford's original strategy (Rule 2), we worked harder but got worse performance. Some people seem to think
 

--- a/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
+++ b/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
@@ -9,7 +9,7 @@ knitr::knit_hooks$set(crop = knitr::hook_pdfcrop)
 source(here::here("R/functions/main-functions.R"))
 ```
 
-### Rules 3 and 4 of the Funnel
+## Rules 3 and 4 of the Funnel
 
 The motivation for the various Rules of the Funnel is discussed in *DemDim* Chapter 5, so there is no need for me to go into great detail here. The important issue here is how well they work. So I'll summarise the motivations for Rules 3 and 4 quite briefly. Firstly, Rule 2 was a relatively complicated operation—you might have had to concentrate quite hard to get it right. Rule 3 is a rather easier and (at least at first sight) an apparently rather innocent variant of Rule 2. Rule 4 is quite different from both of them: it concentrates on trying to minimise the average short-term variation. The latter is, of course, an interesting mixture of good and bad. It is certainly good to reduce variation, but is it wise to do so only in the *short* term? Let's carry out similar procedures as previously, but now for Rules 3 and 4, and see what happens.
 
@@ -164,7 +164,7 @@ Recall that the very first stage in Rule 3 was identical to that in Rule 2 but, 
 
 <div class="separator_blue"></div>
 
-### Rule 4 of the Funnel
+## Rule 4 of the Funnel
 
 Lacking basic understanding of variation, management may with best intentions have used Rules 2 and/or 3 in the hope that they would produce better results than Rule 1. They have failed dismally: instead they have considerably increased variation. Since it is good to reduce variation, they strive to minimise variation *at least in the short term*. Certainly there are circumstances where this may seem quite reasonable in practice. For example, if you don't get exactly what you want from a supplier, but at least what you receive doesn't change much from one delivery to the next, it is quite possible that you can learn to "cope" (for a while) with whatever arrives. The situation that really throws you is when you get dramatic changes from one delivery to the next (which presumably is what happened to you sooner or later during Rule 3)—that's part of the motivation for trying Rule 4.
 

--- a/content/days/day-03/13-summary.qmd
+++ b/content/days/day-03/13-summary.qmd
@@ -9,7 +9,7 @@ knitr::knit_hooks$set(crop = knitr::hook_pdfcrop)
 source(here::here("R/functions/main-functions.R"))
 ```
 
-### Summary
+## Summary
 
 As has been obvious for a while (if not from the very start!), you know that, assuming we are "stuck" with the amount of variation represented by throwing the two dice, the best thing to do is to put the funnel at the desired value of 30 and *leave it there*. Moving the funnel anywhere at any time following any "strategy" will "only make things worse". I trust that sounds familiar!
 
@@ -25,7 +25,7 @@ Finally in this Major Activity, please take a brief look at a couple of runs of 
 
 In Part A of the Optional Extras section we shall examine in detail what happens to control charts when presented with the data from the two simulations of the Funnel Experiment studied in the Appendix. However, particularly in case you decide that that optional material is not for you, Activities 3–i and 3–j consider some general effects of putting data from the four Rules of the Funnel onto control charts.
 
-### Four-Rule Comparison
+## Four-Rule Comparison
 
 The charts below compare the outcomes from all four Rules using the same dice sequence. This is the key advantage of the digital version: you can see all four behaviours side by side.
 
@@ -118,7 +118,7 @@ summaryR4 = runAllStages(4, diceSeqSummary)
 }
 ```
 
-### Summary Statistics
+## Summary Statistics
 
 ```{ojs}
 {
@@ -160,7 +160,7 @@ summaryR4 = runAllStages(4, diceSeqSummary)
 
 <div class="thought">
 
-# ACTIVITY 3–i
+## ACTIVITY 3–i
 
 Having spent much of this morning on beginners to get used to control charts and now this afternoon on the Funnel Experiment, this is a useful Activity which involves both of them. However, if you are a Stats-level 0 student then this possibly isn't for you.
 
@@ -200,7 +200,7 @@ Click this after writing your comments
 
 <div class="thought_commentary">
 
-# ACTIVITY 3–j
+## ACTIVITY 3–j
 
 Now that you have completed the Major Activity and after reading *DemDim* Chapter 5, it would be good if you could spend the final few minutes summarising some illustrations of your own. You will find further suggestions in the relevant discussion in the Appendix—but don't look at it just yet!
 
@@ -222,7 +222,7 @@ As mentioned on page 56, the data from the two runs of the Funnel Experiment tha
 
 <div class="separator_blue"></div>
 
-### Start Over with New Dice
+## Start Over with New Dice
 
 If you'd like to repeat the entire experiment with a fresh set of dice rolls, click the button below. This will clear your saved dice sequence so that the next time you visit the earlier chapters, a brand new sequence will be generated.
 

--- a/content/days/day-04/02-the-joiner-triangle.qmd
+++ b/content/days/day-04/02-the-joiner-triangle.qmd
@@ -19,7 +19,7 @@ Going right back to Dr Shewhart's formative work in the 1920s, we know that the 
 
 <div class="thought_commentary">
 
-# ACTIVITY 4–a
+## ACTIVITY 4–a
 
 This Activity is in three parts. All three parts are likely to involve some deep thought—but I'm giving you *plenty* of time! In the case of three cases, if you have not made much progress after, say, five minutes or so then I'll be giving a few brief suggestions. See also Appendix page 21 to get started.
 
@@ -69,7 +69,7 @@ The words "All One Team" surely speak for themselves. They have strong connectio
 
 <div class="thought_commentary">
 
-# ACTIVITY 4–b
+## ACTIVITY 4–b
 
 Again consider situations familiar to you, whether in your family, perhaps in clubs or societies with which you are involved.
 
@@ -118,7 +118,7 @@ However, as Brian did also include "statistical thinking" and "special and commo
 
 <div class="thought_commentary">
 
-# PAUSE FOR THOUGHT 4–c
+## PAUSE FOR THOUGHT 4–c
 
 Take another look at Deming's Chain Reaction at the bottom of *DemDim* page 13. In later years, there was one link in the Chain Reaction which Dr Deming wished he had expressed differently. Can you suggest which it was, and why, and eventually how he decided he had done it better?
 
@@ -154,7 +154,7 @@ But is it really beyond rhyme and reason to think of improving quality to the ex
 
 <div class="thought_commentary">
 
-# ACTIVITY 4–d
+## ACTIVITY 4–d
 
 Imagine the following situation. You want to celebrate, say, an anniversary or a birthday. So you and your friend / spouse / partner arrange to go out to dinner, perhaps to a restaurant that you haven't previously visited. Let me suggest three scenarios to you. At the end of the evening…
 


### PR DESCRIPTION
## Summary
- Eliminate duplicate `<h1>` elements and `h1`-to-`h3` skips across 24 files in Days 1-4 to comply with WCAG 1.3.1 (Info and Relationships)
- Demote content `#` headings to `##`, promote orphan `###` to `##`, and adjust child headings accordingly (e.g. `## Technical Aid` → `### Technical Aid`)
- Update CSS selectors (`.thought h1`, `.thought_commentary h1`, `.major_activity_title h1`) to target `h2` to preserve styling

## Test plan
- [x] `quarto render` builds successfully
- [x] Automated heading outline check on all rendered HTML confirms: every page has exactly one `h1`, no heading levels are skipped
- [ ] Visual check that Activity, Pause for Thought, and Major Activity headings retain their styling

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)