### PR TITLE
Pin all build tool versions for reproducible builds

### DIFF
--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 'release'
+        r-version: '4.4.0'  # Must match renv.lock R version
         use-public-rspm: true
         
     - name: Cache system dependencies
@@ -49,6 +49,8 @@ jobs:
 
     - name: Setup Pandoc
       uses: r-lib/actions/setup-pandoc@v2
+      with:
+        pandoc-version: '3.1.11'  # Pinned for reproducible builds
       
     - name: Cache Quarto installation
       id: cache-quarto
@@ -58,6 +60,7 @@ jobs:
         key: quarto-1.4.549
         
     - name: Install Quarto
+      # Pinned to 1.4.549 — last tested version. Upgrade intentionally, not automatically.
       if: steps.cache-quarto.outputs.cache-hit != 'true'
       run: |
         curl -LO https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.549/quarto-1.4.549-linux-amd64.deb
@@ -70,8 +73,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.local/share/renv
-        key: ${{ runner.os }}-renv-${{ hashFiles('renv.lock') }}
-        restore-keys: ${{ runner.os }}-renv-
+        key: ${{ runner.os }}-r4.4.0-renv-${{ hashFiles('renv.lock') }}
+        restore-keys: ${{ runner.os }}-r4.4.0-renv-
 
     - name: Restore R packages
       shell: Rscript {0}

--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Setup R
+      id: setup-r
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: '4.4.0'  # Must match renv.lock R version
@@ -60,7 +61,7 @@ jobs:
         key: quarto-1.4.549
         
     - name: Install Quarto
-      # Pinned to 1.4.549 — last tested version. Upgrade intentionally, not automatically.
+      # Pinned to 1.4.549 — last tested version (reviewed 2026-03). Upgrade intentionally.
       if: steps.cache-quarto.outputs.cache-hit != 'true'
       run: |
         curl -LO https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.549/quarto-1.4.549-linux-amd64.deb
@@ -73,8 +74,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.local/share/renv
-        key: ${{ runner.os }}-r4.4.0-renv-${{ hashFiles('renv.lock') }}
-        restore-keys: ${{ runner.os }}-r4.4.0-renv-
+        key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}
+        restore-keys: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-
 
     - name: Restore R packages
       shell: Rscript {0}

--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Setup Pandoc
       uses: r-lib/actions/setup-pandoc@v2
       with:
-        pandoc-version: '3.1.11'  # Pinned for reproducible builds
+        pandoc-version: '3.1.11'  # Pinned for reproducible builds (reviewed 2026-03)
       
     - name: Cache Quarto installation
       id: cache-quarto

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Pre-install igraph in renv library
       run: |
-        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, substr(R.version$minor,1,1), sep=\".\"))')/x86_64-pc-linux-gnu"
+        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, strsplit(R.version$minor, "\\\\.")[[1]][1], sep="."))')/x86_64-pc-linux-gnu"
         mkdir -p "$R_LIBPATH"
         Rscript -e "install.packages('igraph', lib = '$R_LIBPATH')"
 
@@ -59,9 +59,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: renv/library
-        key: ${{ runner.os }}-r4.4.0-renv-${{ hashFiles('renv.lock') }}
+        key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}
         restore-keys: |
-          ${{ runner.os }}-r4.4.0-renv-
+          ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-
 
     - name: Setup Pandoc
       uses: r-lib/actions/setup-pandoc@v2
@@ -69,8 +69,7 @@ jobs:
         pandoc-version: '3.1.11'  # Pinned for reproducible builds
       
     - name: Install Quarto
-      # Pinned to 1.4.549 — last tested version. Upgrade intentionally, not automatically.
-      # Latest available: 1.9.x (check https://github.com/quarto-dev/quarto-cli/releases)
+      # Pinned to 1.4.549 — last tested version (reviewed 2026-03). Upgrade intentionally.
       run: |
         curl -LO https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.549/quarto-1.4.549-linux-amd64.deb
         sudo dpkg -i quarto-1.4.549-linux-amd64.deb
@@ -103,7 +102,7 @@ jobs:
 
     - name: Check renv library permissions
       run: |
-        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, substr(R.version$minor,1,1), sep=\".\"))')/x86_64-pc-linux-gnu"
+        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, strsplit(R.version$minor, "\\\\.")[[1]][1], sep="."))')/x86_64-pc-linux-gnu"
         ls -l "$R_LIBPATH"
         
     - name: Build Quarto book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       id: setup-r
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 'release'
+        r-version: '4.4.0'  # Must match renv.lock R version
         
     - name: Install minimal system dependencies
       run: |
@@ -47,7 +47,9 @@ jobs:
 
     - name: Pre-install igraph in renv library
       run: |
-        Rscript -e 'install.packages("igraph", lib = "renv/library/R-4.5/x86_64-pc-linux-gnu")'
+        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, substr(R.version$minor,1,1), sep=\".\"))')/x86_64-pc-linux-gnu"
+        mkdir -p "$R_LIBPATH"
+        Rscript -e "install.packages('igraph', lib = '$R_LIBPATH')"
 
     - name: Test igraph install
       run: |
@@ -57,14 +59,18 @@ jobs:
       uses: actions/cache@v3
       with:
         path: renv/library
-        key: ${{ runner.os }}-renv-${{ hashFiles('renv.lock') }}
+        key: ${{ runner.os }}-r4.4.0-renv-${{ hashFiles('renv.lock') }}
         restore-keys: |
-          ${{ runner.os }}-renv-
+          ${{ runner.os }}-r4.4.0-renv-
 
     - name: Setup Pandoc
       uses: r-lib/actions/setup-pandoc@v2
+      with:
+        pandoc-version: '3.1.11'  # Pinned for reproducible builds
       
     - name: Install Quarto
+      # Pinned to 1.4.549 — last tested version. Upgrade intentionally, not automatically.
+      # Latest available: 1.9.x (check https://github.com/quarto-dev/quarto-cli/releases)
       run: |
         curl -LO https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.549/quarto-1.4.549-linux-amd64.deb
         sudo dpkg -i quarto-1.4.549-linux-amd64.deb
@@ -97,7 +103,8 @@ jobs:
 
     - name: Check renv library permissions
       run: |
-        ls -l /home/runner/work/twelve_days_to_deming/twelve_days_to_deming/renv/library/R-4.5/x86_64-pc-linux-gnu
+        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, substr(R.version$minor,1,1), sep=\".\"))')/x86_64-pc-linux-gnu"
+        ls -l "$R_LIBPATH"
         
     - name: Build Quarto book
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         Rscript -e 'library(igraph); sessionInfo()'
 
     - name: Cache R packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: renv/library
         key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}
@@ -66,7 +66,7 @@ jobs:
     - name: Setup Pandoc
       uses: r-lib/actions/setup-pandoc@v2
       with:
-        pandoc-version: '3.1.11'  # Pinned for reproducible builds
+        pandoc-version: '3.1.11'  # Pinned for reproducible builds (reviewed 2026-03)
       
     - name: Install Quarto
       # Pinned to 1.4.549 — last tested version (reviewed 2026-03). Upgrade intentionally.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Pre-install igraph in renv library
       run: |
-        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, strsplit(R.version$minor, "\\\\.")[[1]][1], sep="."))')/x86_64-pc-linux-gnu"
+        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, strsplit(R.version$minor, ".", fixed=TRUE)[[1]][1], sep="."))')/x86_64-pc-linux-gnu"
         mkdir -p "$R_LIBPATH"
         Rscript -e "install.packages('igraph', lib = '$R_LIBPATH')"
 
@@ -102,7 +102,7 @@ jobs:
 
     - name: Check renv library permissions
       run: |
-        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, strsplit(R.version$minor, "\\\\.")[[1]][1], sep="."))')/x86_64-pc-linux-gnu"
+        R_LIBPATH="renv/library/R-$(Rscript -e 'cat(paste(R.version$major, strsplit(R.version$minor, ".", fixed=TRUE)[[1]][1], sep="."))')/x86_64-pc-linux-gnu"
         ls -l "$R_LIBPATH"
         
     - name: Build Quarto book


### PR DESCRIPTION
## Summary
- Pin R version to `4.4.0` (matching `renv.lock`) — was `'release'` which silently upgraded to 4.5.x
- Pin Pandoc to `3.1.11` — was floating with no version specified
- Replace hardcoded `R-4.5` library paths with dynamically derived paths
- Add R version to cache keys to prevent ABI-incompatible cache reuse
- Document Quarto 1.4.549 pin as intentional (already was pinned, just undocumented)
- Applied consistently across both `deploy.yml` and `deploy-optimized.yml`

Closes #46

## Test plan
- [ ] CI build passes with pinned R 4.4.0
- [ ] renv restore succeeds (no R version mismatch)
- [ ] Quarto render produces expected output
- [ ] Two builds from the same commit produce identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)