### PR TITLE
Add non-color indicators for WCAG 1.4.1 compliance (issue #34)

### DIFF
--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -232,13 +232,13 @@ export function renderTrackSVG(currentStage, trackRange) {
   if (currentStage) {
     const funnelX = (currentStage.funnelBefore - trackRange.min) * cellW + padding + cellW / 2;
     const funnelY = padding + 10;
-    svg += `<polygon points="${funnelX - 10},${funnelY} ${funnelX + 10},${funnelY} ${funnelX},${funnelY + 18}" fill="#3366cc" stroke="#1a3366" stroke-width="1.5"><title>Funnel</title></polygon>`;
+    svg += `<polygon points="${funnelX - 10},${funnelY} ${funnelX + 10},${funnelY} ${funnelX},${funnelY + 18}" fill="#3366cc" stroke="#1a3366" stroke-width="1.5"/>`;
     svg += `<text x="${funnelX}" y="${funnelY - 4}" text-anchor="middle" font-size="10" fill="#3366cc" font-weight="bold">▼</text>`;
 
     // Draw marble icon (brown/orange circle)
     const marbleX = (currentStage.marblePos - trackRange.min) * cellW + padding + cellW / 2;
     const marbleY = 50 + padding + cellH + 15;
-    svg += `<circle cx="${marbleX}" cy="${marbleY}" r="10" fill="#cc6633" stroke="#663300" stroke-width="1.5"><title>Marble</title></circle>`;
+    svg += `<circle cx="${marbleX}" cy="${marbleY}" r="10" fill="#cc6633" stroke="#663300" stroke-width="1.5"/>`;
   }
 
   svg += `</svg>`;

--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -232,13 +232,13 @@ export function renderTrackSVG(currentStage, trackRange) {
   if (currentStage) {
     const funnelX = (currentStage.funnelBefore - trackRange.min) * cellW + padding + cellW / 2;
     const funnelY = padding + 10;
-    svg += `<polygon points="${funnelX - 10},${funnelY} ${funnelX + 10},${funnelY} ${funnelX},${funnelY + 18}" fill="#3366cc" stroke="#1a3366" stroke-width="1.5"/>`;
+    svg += `<polygon points="${funnelX - 10},${funnelY} ${funnelX + 10},${funnelY} ${funnelX},${funnelY + 18}" fill="#3366cc" stroke="#1a3366" stroke-width="1.5"><title>Funnel</title></polygon>`;
     svg += `<text x="${funnelX}" y="${funnelY - 4}" text-anchor="middle" font-size="10" fill="#3366cc" font-weight="bold">▼</text>`;
 
     // Draw marble icon (brown/orange circle)
     const marbleX = (currentStage.marblePos - trackRange.min) * cellW + padding + cellW / 2;
     const marbleY = 50 + padding + cellH + 15;
-    svg += `<circle cx="${marbleX}" cy="${marbleY}" r="10" fill="#cc6633" stroke="#663300" stroke-width="1.5"/>`;
+    svg += `<circle cx="${marbleX}" cy="${marbleY}" r="10" fill="#cc6633" stroke="#663300" stroke-width="1.5"><title>Marble</title></circle>`;
   }
 
   svg += `</svg>`;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -72,7 +72,7 @@ Usage:
   font-weight: bold;
   font-style: italic;
   border-left: 3px solid #0000b3;
-  padding-left: 4px;
+  padding-left: 0.5em;
 }
 
 .foreman-remark {
@@ -333,6 +333,10 @@ button:focus,
   }
   
   .thought_commentary {
+    border: 3px dashed #cc0000;
+  }
+
+  .thought_commentary .collapse {
     border: 3px dashed #cc0000;
   }
 }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -70,6 +70,9 @@ Usage:
 .deming_quote {
   color: #0000b3;
   font-weight: bold;
+  font-style: italic;
+  border-left: 3px solid #0000b3;
+  padding-left: 4px;
 }
 
 .foreman-remark {
@@ -98,7 +101,7 @@ Usage:
 }
 
 .thought_commentary {
-  border: 2px solid #ff0000;
+  border: 2px dashed #ff0000;
   padding: 10px;
   margin: 20px;
 }
@@ -110,7 +113,7 @@ Usage:
 
 .thought_commentary .collapse {
   background-color: #ffe0e0;
-  border: 2px solid #ff0000;
+  border: 2px dashed #ff0000;
   padding: 10px;
   margin: 20px;
 }
@@ -322,6 +325,7 @@ button:focus,
   .deming_quote {
     color: #000080;
     font-weight: bold;
+    border-left-color: #000080;
   }
   
   .thought {
@@ -329,7 +333,7 @@ button:focus,
   }
   
   .thought_commentary {
-    border: 3px solid #cc0000;
+    border: 3px dashed #cc0000;
   }
 }
 


### PR DESCRIPTION
## Summary
- `.deming_quote`: added italic styling and left border so meaning is conveyed without color
- `.thought_commentary`: changed border from solid to dashed, distinguishing it from `.thought` in greyscale
- SVG funnel (`<polygon>`) and marble (`<circle>`) now contain `<title>` child elements for screen readers

Closes #34

## Test plan
- [ ] `quarto preview` renders without errors
- [ ] `.deming_quote` spans show italic text with a left border
- [ ] `.thought` boxes have solid borders, `.thought_commentary` boxes have dashed borders
- [ ] Use browser DevTools to desaturate the page — element types remain distinguishable
- [ ] Funnel experiment SVG shapes announce "Funnel" / "Marble" to screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)