### PR TITLE
Extract duplicated OJS patterns into funnel-experiment helpers (#48)

### DIFF
--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -1,6 +1,6 @@
 // ============================================================
 // Funnel Experiment — shared pure-function module
-// Used by OJS cells in chapters 11, 12, and 13 of Day 3
+// Used by OJS cells in chapters 11 and 12 of Day 3
 // ============================================================
 
 // --- Constants ---
@@ -373,10 +373,11 @@ export function renderDataTable(rule, stages, tableIndex) {
 }
 
 // --- Chapter-level helpers ---
-// These reduce duplication across OJS cells in chapters 11, 12, and 13.
+// These reduce duplication across OJS cells in chapters 11 and 12.
 // Each returns an HTML string; OJS cells wrap with html`${...}`.
 
-// Status bar showing rule info, current stage, last outcome, and funnel position
+// Status bar showing rule info, current stage, last outcome, and funnel position.
+// `description` must be a trusted string literal (not user input) — it is injected unescaped.
 export function renderStatusHTML(rule, description, counter, visible, totalStages, target) {
   const lastOutcome = counter > 0 ? visible[visible.length - 1].marblePos : null;
   const funnelPos = counter > 0 ? visible[visible.length - 1].funnelAfter : target;
@@ -394,8 +395,8 @@ export function renderStatusHTML(rule, description, counter, visible, totalStage
 }
 
 // Track SVG wrapped in its scroll container
-export function renderTrackHTML(counter, visible, allStages) {
-  const currentStage = counter > 0 ? visible[visible.length - 1] : null;
+export function renderTrackHTML(visible, allStages) {
+  const currentStage = visible.length > 0 ? visible[visible.length - 1] : null;
   const trackRange = computeTrackRange(allStages);
   return `<div class="fe-track-container">${renderTrackSVG(currentStage, trackRange)}</div>`;
 }
@@ -408,7 +409,7 @@ export function renderStageButtonsHTML(counter, totalStages) {
        + `<button class="fe-button fe-button-complete fe-stage-complete"${d}>Complete Remaining Stages</button></div>`;
 }
 
-// Three sub-tables (stages 1-14, 15-27, 28-40) wrapped in scroll containers
+// Three sub-tables wrapped in scroll containers (indices 0/1/2 → stages 1-14, 15-27, 28-40)
 export function renderDataTablesHTML(rule, visible) {
   return `<div class="fe-track-container">${renderDataTable(rule, visible, 0)}</div>`
        + `<div class="fe-track-container">${renderDataTable(rule, visible, 1)}</div>`

--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -371,3 +371,46 @@ export function renderDataTable(rule, stages, tableIndex) {
   html += `</tbody></table>`;
   return html;
 }
+
+// --- Chapter-level helpers ---
+// These reduce duplication across OJS cells in chapters 11, 12, and 13.
+// Each returns an HTML string; OJS cells wrap with html`${...}`.
+
+// Status bar showing rule info, current stage, last outcome, and funnel position
+export function renderStatusHTML(rule, description, counter, visible, totalStages, target) {
+  const lastOutcome = counter > 0 ? visible[visible.length - 1].marblePos : null;
+  const funnelPos = counter > 0 ? visible[visible.length - 1].funnelAfter : target;
+  const funnelLabel = rule === 1 ? "Funnel always at" : (counter > 0 ? "Funnel now at" : "Funnel at");
+
+  let s = `<div class="fe-status" role="status" aria-live="polite" aria-atomic="true">`;
+  s += `<strong>Rule ${rule} — ${description}</strong><br>`;
+  s += `Stage: <strong>${counter}</strong> of ${totalStages}`;
+  if (lastOutcome !== null) {
+    s += ` | Last outcome: <strong class="fe-outcome-value">${lastOutcome}</strong>`;
+  }
+  s += ` | ${funnelLabel}: <strong class="fe-funnel-value">${funnelPos}</strong>`;
+  s += `</div>`;
+  return s;
+}
+
+// Track SVG wrapped in its scroll container
+export function renderTrackHTML(counter, visible, allStages) {
+  const currentStage = counter > 0 ? visible[visible.length - 1] : null;
+  const trackRange = computeTrackRange(allStages);
+  return `<div class="fe-track-container">${renderTrackSVG(currentStage, trackRange)}</div>`;
+}
+
+// Next/Complete buttons — returns HTML with .fe-stage-next and .fe-stage-complete classes
+// Callers attach onclick handlers via querySelector in OJS
+export function renderStageButtonsHTML(counter, totalStages) {
+  const d = counter >= totalStages ? " disabled" : "";
+  return `<div><button class="fe-button fe-stage-next"${d}>Next Stage \u2192</button>`
+       + `<button class="fe-button fe-button-complete fe-stage-complete"${d}>Complete Remaining Stages</button></div>`;
+}
+
+// Three sub-tables (stages 1-14, 15-27, 28-40) wrapped in scroll containers
+export function renderDataTablesHTML(rule, visible) {
+  return `<div class="fe-track-container">${renderDataTable(rule, visible, 0)}</div>`
+       + `<div class="fe-track-container">${renderDataTable(rule, visible, 1)}</div>`
+       + `<div class="fe-track-container">${renderDataTable(rule, visible, 2)}</div>`;
+}

--- a/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
+++ b/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
@@ -99,7 +99,7 @@ html`${renderStatusHTML(2, "Ford's First Strategy (Compensation)", rule2Counter,
 ```
 
 ```{ojs}
-html`${renderTrackHTML(rule2Counter, rule2Visible, rule2AllStages)}`
+html`${renderTrackHTML(rule2Visible, rule2AllStages)}`
 ```
 
 ```{ojs}
@@ -191,7 +191,7 @@ html`${renderStatusHTML(1, "Ford's Second Strategy (Leave the Funnel Alone)", ru
 ```
 
 ```{ojs}
-html`${renderTrackHTML(rule1Counter, rule1Visible, rule1AllStages)}`
+html`${renderTrackHTML(rule1Visible, rule1AllStages)}`
 ```
 
 ```{ojs}

--- a/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
+++ b/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
@@ -53,7 +53,8 @@ We'll use my own dice-scores to start with so that you can follow my illustratio
 // Import the funnel experiment module
 import {
   generateDiceSequence, saveDiceSequence, loadDiceSequence,
-  runAllStages, computeTrackRange, renderTrackSVG, renderDataTable,
+  runAllStages, renderStatusHTML, renderTrackHTML,
+  renderStageButtonsHTML, renderDataTablesHTML,
   TARGET, TOTAL_STAGES
 } from "../../../assets/scripts/funnel-experiment.js"
 ```
@@ -94,52 +95,28 @@ rule2Visible = rule2AllStages.slice(0, rule2Counter)
 ```
 
 ```{ojs}
-// Status bar
-html`<div class="fe-status" role="status" aria-live="polite" aria-atomic="true">
-  <strong>Rule 2 — Ford's First Strategy (Compensation)</strong><br>
-  Stage: <strong>${rule2Counter}</strong> of ${TOTAL_STAGES}
-  ${rule2Counter > 0 ? ` | Last outcome: <strong class="fe-outcome-value">${rule2Visible[rule2Visible.length - 1].marblePos}</strong>` : ""}
-  ${rule2Counter > 0 ? ` | Funnel now at: <strong class="fe-funnel-value">${rule2Visible[rule2Visible.length - 1].funnelAfter}</strong>` : ` | Funnel at: <strong class="fe-funnel-value">${TARGET}</strong>`}
-</div>`
+html`${renderStatusHTML(2, "Ford's First Strategy (Compensation)", rule2Counter, rule2Visible, TOTAL_STAGES, TARGET)}`
 ```
 
 ```{ojs}
-// Track visualisation
-{
-  const currentStage = rule2Counter > 0 ? rule2Visible[rule2Visible.length - 1] : null;
-  const trackRange = computeTrackRange(rule2AllStages);
-  const svgStr = renderTrackSVG(currentStage, trackRange);
-  return html`<div class="fe-track-container">${html`${svgStr}`}</div>`;
-}
+html`${renderTrackHTML(rule2Counter, rule2Visible, rule2AllStages)}`
 ```
 
 ```{ojs}
-// Action buttons
 {
-  const nextBtn = html`<button class="fe-button" ${rule2Counter >= TOTAL_STAGES ? "disabled" : ""}>Next Stage →</button>`;
-  const completeBtn = html`<button class="fe-button fe-button-complete" ${rule2Counter >= TOTAL_STAGES ? "disabled" : ""}>Complete Remaining Stages</button>`;
-
-  nextBtn.onclick = () => {
+  const el = html`${renderStageButtonsHTML(rule2Counter, TOTAL_STAGES)}`;
+  el.querySelector('.fe-stage-next').onclick = () => {
     if (rule2Counter < TOTAL_STAGES) mutable rule2Counter = rule2Counter + 1;
   };
-  completeBtn.onclick = () => {
+  el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule2Counter = TOTAL_STAGES;
   };
-
-  return html`<div>${nextBtn}${completeBtn}</div>`;
+  return el;
 }
 ```
 
 ```{ojs}
-// Data tables (3 sub-tables matching source layout)
-{
-  const t1 = renderDataTable(2, rule2Visible, 0);
-  const t2 = renderDataTable(2, rule2Visible, 1);
-  const t3 = renderDataTable(2, rule2Visible, 2);
-  return html`<div class="fe-track-container">${html`${t1}`}</div>
-              <div class="fe-track-container">${html`${t2}`}</div>
-              <div class="fe-track-container">${html`${t3}`}</div>`;
-}
+html`${renderDataTablesHTML(2, rule2Visible)}`
 ```
 
 Finally, summarise the outcomes that you've just generated in a histogram. The "outcomes" are the resting positions of the <span class="fe-marble">marble</span>, i.e. the positions of ● in the yellow-shaded rows in your table. However, now that you have as many as 40 data-values to include in the histogram, we need to think more carefully than before about what would be an efficient way to produce it.
@@ -210,52 +187,28 @@ rule1Visible = rule1AllStages.slice(0, rule1Counter)
 ```
 
 ```{ojs}
-// Status bar for Rule 1
-html`<div class="fe-status" role="status" aria-live="polite" aria-atomic="true">
-  <strong>Rule 1 — Ford's Second Strategy (Leave the Funnel Alone)</strong><br>
-  Stage: <strong>${rule1Counter}</strong> of ${TOTAL_STAGES}
-  ${rule1Counter > 0 ? ` | Last outcome: <strong class="fe-outcome-value">${rule1Visible[rule1Visible.length - 1].marblePos}</strong>` : ""}
-  | Funnel always at: <strong class="fe-funnel-value">${TARGET}</strong>
-</div>`
+html`${renderStatusHTML(1, "Ford's Second Strategy (Leave the Funnel Alone)", rule1Counter, rule1Visible, TOTAL_STAGES, TARGET)}`
 ```
 
 ```{ojs}
-// Track visualisation for Rule 1
-{
-  const currentStage = rule1Counter > 0 ? rule1Visible[rule1Visible.length - 1] : null;
-  const trackRange = computeTrackRange(rule1AllStages);
-  const svgStr = renderTrackSVG(currentStage, trackRange);
-  return html`<div class="fe-track-container">${html`${svgStr}`}</div>`;
-}
+html`${renderTrackHTML(rule1Counter, rule1Visible, rule1AllStages)}`
 ```
 
 ```{ojs}
-// Action buttons for Rule 1
 {
-  const nextBtn = html`<button class="fe-button" ${rule1Counter >= TOTAL_STAGES ? "disabled" : ""}>Next Stage →</button>`;
-  const completeBtn = html`<button class="fe-button fe-button-complete" ${rule1Counter >= TOTAL_STAGES ? "disabled" : ""}>Complete Remaining Stages</button>`;
-
-  nextBtn.onclick = () => {
+  const el = html`${renderStageButtonsHTML(rule1Counter, TOTAL_STAGES)}`;
+  el.querySelector('.fe-stage-next').onclick = () => {
     if (rule1Counter < TOTAL_STAGES) mutable rule1Counter = rule1Counter + 1;
   };
-  completeBtn.onclick = () => {
+  el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule1Counter = TOTAL_STAGES;
   };
-
-  return html`<div>${nextBtn}${completeBtn}</div>`;
+  return el;
 }
 ```
 
 ```{ojs}
-// Data tables for Rule 1
-{
-  const t1 = renderDataTable(1, rule1Visible, 0);
-  const t2 = renderDataTable(1, rule1Visible, 1);
-  const t3 = renderDataTable(1, rule1Visible, 2);
-  return html`<div class="fe-track-container">${html`${t1}`}</div>
-              <div class="fe-track-container">${html`${t2}`}</div>
-              <div class="fe-track-container">${html`${t3}`}</div>`;
-}
+html`${renderDataTablesHTML(1, rule1Visible)}`
 ```
 
 So now summarise your new data in a histogram as before.

--- a/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
+++ b/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
@@ -90,7 +90,7 @@ html`${renderStatusHTML(3, "Symmetric Placement", rule3Counter, rule3Visible, TO
 ```
 
 ```{ojs}
-html`${renderTrackHTML(rule3Counter, rule3Visible, rule3AllStages)}`
+html`${renderTrackHTML(rule3Visible, rule3AllStages)}`
 ```
 
 ```{ojs}
@@ -194,7 +194,7 @@ html`${renderStatusHTML(4, "Place Funnel Where Marble Landed", rule4Counter, rul
 ```
 
 ```{ojs}
-html`${renderTrackHTML(rule4Counter, rule4Visible, rule4AllStages)}`
+html`${renderTrackHTML(rule4Visible, rule4AllStages)}`
 ```
 
 ```{ojs}

--- a/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
+++ b/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
@@ -47,7 +47,8 @@ Just for interest, take a moment's thought to guess what will happen in the long
 // Import the funnel experiment module
 import {
   generateDiceSequence, saveDiceSequence, loadDiceSequence,
-  runAllStages, computeTrackRange, renderTrackSVG, renderDataTable,
+  runAllStages, renderStatusHTML, renderTrackHTML,
+  renderStageButtonsHTML, renderDataTablesHTML,
   TARGET, TOTAL_STAGES
 } from "../../../assets/scripts/funnel-experiment.js"
 ```
@@ -85,48 +86,28 @@ rule3Visible = rule3AllStages.slice(0, rule3Counter)
 ```
 
 ```{ojs}
-html`<div class="fe-status" role="status" aria-live="polite" aria-atomic="true">
-  <strong>Rule 3 — Symmetric Placement</strong><br>
-  Stage: <strong>${rule3Counter}</strong> of ${TOTAL_STAGES}
-  ${rule3Counter > 0 ? ` | Last outcome: <strong class="fe-outcome-value">${rule3Visible[rule3Visible.length - 1].marblePos}</strong>` : ""}
-  ${rule3Counter > 0 ? ` | Funnel now at: <strong class="fe-funnel-value">${rule3Visible[rule3Visible.length - 1].funnelAfter}</strong>` : ` | Funnel at: <strong class="fe-funnel-value">${TARGET}</strong>`}
-</div>`
+html`${renderStatusHTML(3, "Symmetric Placement", rule3Counter, rule3Visible, TOTAL_STAGES, TARGET)}`
+```
+
+```{ojs}
+html`${renderTrackHTML(rule3Counter, rule3Visible, rule3AllStages)}`
 ```
 
 ```{ojs}
 {
-  const currentStage = rule3Counter > 0 ? rule3Visible[rule3Visible.length - 1] : null;
-  const trackRange = computeTrackRange(rule3AllStages);
-  const svgStr = renderTrackSVG(currentStage, trackRange);
-  return html`<div class="fe-track-container">${html`${svgStr}`}</div>`;
-}
-```
-
-```{ojs}
-{
-  const nextBtn = html`<button class="fe-button" ${rule3Counter >= TOTAL_STAGES ? "disabled" : ""}>Next Stage →</button>`;
-  const completeBtn = html`<button class="fe-button fe-button-complete" ${rule3Counter >= TOTAL_STAGES ? "disabled" : ""}>Complete Remaining Stages</button>`;
-
-  nextBtn.onclick = () => {
+  const el = html`${renderStageButtonsHTML(rule3Counter, TOTAL_STAGES)}`;
+  el.querySelector('.fe-stage-next').onclick = () => {
     if (rule3Counter < TOTAL_STAGES) mutable rule3Counter = rule3Counter + 1;
   };
-  completeBtn.onclick = () => {
+  el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule3Counter = TOTAL_STAGES;
   };
-
-  return html`<div>${nextBtn}${completeBtn}</div>`;
+  return el;
 }
 ```
 
 ```{ojs}
-{
-  const t1 = renderDataTable(3, rule3Visible, 0);
-  const t2 = renderDataTable(3, rule3Visible, 1);
-  const t3 = renderDataTable(3, rule3Visible, 2);
-  return html`<div class="fe-track-container">${html`${t1}`}</div>
-              <div class="fe-track-container">${html`${t2}`}</div>
-              <div class="fe-track-container">${html`${t3}`}</div>`;
-}
+html`${renderDataTablesHTML(3, rule3Visible)}`
 ```
 
 And now draw the run chart, continuing on from my first five points. Again, as with the histograms, there's no need to be too artistic about it—please yourself whether or not you use a ruler!
@@ -209,48 +190,28 @@ rule4Visible = rule4AllStages.slice(0, rule4Counter)
 ```
 
 ```{ojs}
-html`<div class="fe-status" role="status" aria-live="polite" aria-atomic="true">
-  <strong>Rule 4 — Place Funnel Where Marble Landed</strong><br>
-  Stage: <strong>${rule4Counter}</strong> of ${TOTAL_STAGES}
-  ${rule4Counter > 0 ? ` | Last outcome: <strong class="fe-outcome-value">${rule4Visible[rule4Visible.length - 1].marblePos}</strong>` : ""}
-  ${rule4Counter > 0 ? ` | Funnel now at: <strong class="fe-funnel-value">${rule4Visible[rule4Visible.length - 1].funnelAfter}</strong>` : ` | Funnel at: <strong class="fe-funnel-value">${TARGET}</strong>`}
-</div>`
+html`${renderStatusHTML(4, "Place Funnel Where Marble Landed", rule4Counter, rule4Visible, TOTAL_STAGES, TARGET)}`
+```
+
+```{ojs}
+html`${renderTrackHTML(rule4Counter, rule4Visible, rule4AllStages)}`
 ```
 
 ```{ojs}
 {
-  const currentStage = rule4Counter > 0 ? rule4Visible[rule4Visible.length - 1] : null;
-  const trackRange = computeTrackRange(rule4AllStages);
-  const svgStr = renderTrackSVG(currentStage, trackRange);
-  return html`<div class="fe-track-container">${html`${svgStr}`}</div>`;
-}
-```
-
-```{ojs}
-{
-  const nextBtn = html`<button class="fe-button" ${rule4Counter >= TOTAL_STAGES ? "disabled" : ""}>Next Stage →</button>`;
-  const completeBtn = html`<button class="fe-button fe-button-complete" ${rule4Counter >= TOTAL_STAGES ? "disabled" : ""}>Complete Remaining Stages</button>`;
-
-  nextBtn.onclick = () => {
+  const el = html`${renderStageButtonsHTML(rule4Counter, TOTAL_STAGES)}`;
+  el.querySelector('.fe-stage-next').onclick = () => {
     if (rule4Counter < TOTAL_STAGES) mutable rule4Counter = rule4Counter + 1;
   };
-  completeBtn.onclick = () => {
+  el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule4Counter = TOTAL_STAGES;
   };
-
-  return html`<div>${nextBtn}${completeBtn}</div>`;
+  return el;
 }
 ```
 
 ```{ojs}
-{
-  const t1 = renderDataTable(4, rule4Visible, 0);
-  const t2 = renderDataTable(4, rule4Visible, 1);
-  const t3 = renderDataTable(4, rule4Visible, 2);
-  return html`<div class="fe-track-container">${html`${t1}`}</div>
-              <div class="fe-track-container">${html`${t2}`}</div>
-              <div class="fe-track-container">${html`${t3}`}</div>`;
-}
+html`${renderDataTablesHTML(4, rule4Visible)}`
 ```
 
 ```{ojs}


### PR DESCRIPTION
## Summary
- Adds four helper functions to `assets/scripts/funnel-experiment.js`: `renderStatusHTML`, `renderTrackHTML`, `renderStageButtonsHTML`, and `renderDataTablesHTML`
- Refactors chapters 11 and 12 to call these helpers instead of inlining ~120 lines of near-identical OJS code across the four funnel rules
- No inline `style=` attributes remain in status bars (already using `fe-outcome-value` / `fe-funnel-value` CSS classes)

Closes #48

## Test plan
- [ ] `quarto preview` — verify all four funnel rule interactives (Rules 1–4) render correctly
- [ ] Step through stages with "Next Stage →" button for each rule
- [ ] Click "Complete Remaining Stages" and verify histograms/run charts appear
- [ ] Confirm status bars update with correct outcome and funnel position values
- [ ] Verify data tables populate correctly for all three sub-table ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)