### PR TITLE
Pin external dependencies to exact versions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@725b9c36f61150e9be5b9ec02289a9a0cfc21c04  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: '20'
         cache: 'npm'
@@ -33,18 +33,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       
     - name: Setup R
       id: setup-r
-      uses: r-lib/actions/setup-r@v2
+      uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2
       with:
         r-version: '4.4.0'  # Must match renv.lock R version
         use-public-rspm: true
         
     - name: Cache system dependencies
       id: cache-sys-deps
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: /var/cache/apt
         key: ${{ runner.os }}-sys-deps-v1
@@ -68,13 +68,13 @@ jobs:
           libglpk-dev
 
     - name: Setup Pandoc
-      uses: r-lib/actions/setup-pandoc@v2
+      uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2
       with:
         pandoc-version: '3.1.11'  # Pinned for reproducible builds (reviewed 2026-03)
       
     - name: Cache Quarto installation
       id: cache-quarto
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: /opt/quarto
         key: quarto-1.4.549
@@ -90,7 +90,7 @@ jobs:
       run: echo "/opt/quarto/bin" >> $GITHUB_PATH
 
     - name: Cache R packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: ~/.local/share/renv
         key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: '20'
         cache: 'npm'
@@ -33,11 +33,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       
     - name: Setup R
       id: setup-r
-      uses: r-lib/actions/setup-r@v2
+      uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2
       with:
         r-version: '4.4.0'  # Must match renv.lock R version
         
@@ -75,7 +75,7 @@ jobs:
         Rscript -e 'library(igraph); sessionInfo()'
 
     - name: Cache R packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: renv/library
         key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}
@@ -83,7 +83,7 @@ jobs:
           ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-
 
     - name: Setup Pandoc
-      uses: r-lib/actions/setup-pandoc@v2
+      uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2
       with:
         pandoc-version: '3.1.11'  # Pinned for reproducible builds (reviewed 2026-03)
       

--- a/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
+++ b/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
@@ -123,7 +123,7 @@ Finally, summarise the outcomes that you've just generated in a histogram. The "
   }
 
   const outcomes = rule2Visible.map(s => s.marblePos);
-  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm");
+  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.16/+esm");
 
   return html`<div role="img" aria-label="Histogram of marble positions for Rule 2 across ${TOTAL_STAGES} stages">
     <span aria-hidden="true">${Plot.plot({
@@ -215,7 +215,7 @@ So now summarise your new data in a histogram as before.
   }
 
   const outcomes = rule1Visible.map(s => s.marblePos);
-  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm");
+  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.16/+esm");
 
   return html`<div role="img" aria-label="Histogram of marble positions for Rule 1 across ${TOTAL_STAGES} stages">
     <span aria-hidden="true">${Plot.plot({

--- a/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
+++ b/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
@@ -116,7 +116,7 @@ Recall that the very first stage in Rule 3 was identical to that in Rule 2 but, 
   }
 
   const data = rule3Visible.map(s => ({ stage: s.stage, outcome: s.marblePos }));
-  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm");
+  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.16/+esm");
 
   return html`<div role="img" aria-label="Run chart of marble positions for Rule 3 across ${TOTAL_STAGES} stages">
     <span aria-hidden="true">${Plot.plot({
@@ -216,7 +216,7 @@ html`${renderDataTablesHTML(4, rule4Visible)}`
   }
 
   const data = rule4Visible.map(s => ({ stage: s.stage, outcome: s.marblePos }));
-  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm");
+  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.16/+esm");
 
   return html`<div role="img" aria-label="Run chart of marble positions for Rule 4 across ${TOTAL_STAGES} stages">
     <span aria-hidden="true">${Plot.plot({

--- a/content/days/day-03/13-summary.qmd
+++ b/content/days/day-03/13-summary.qmd
@@ -57,7 +57,7 @@ summaryR4 = runAllStages(4, diceSeqSummary)
 ```{ojs}
 // Four-way comparison grid
 {
-  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm");
+  const Plot = await import("https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.16/+esm");
 
   function makeHistogram(stages, title, color) {
     const outcomes = stages.map(s => s.marblePos);


### PR DESCRIPTION
## Summary
- **Issue #14**: Pin `@observablehq/plot` from semver range `@0.6` to exact `@0.6.16` across all 5 occurrences in Day 3 funnel experiment files
- **Issue #19**: Pin all GitHub Actions to SHA hashes in all 3 workflow files (`deploy.yml`, `deploy-optimized.yml`, `claude-code-review.yml`)
- **Issue #22**: Already resolved — both workflows already specify `r-version: '4.4.0'` and use consistent `actions/cache@v4`

Closes #14, closes #19, closes #22

## Test plan
- [ ] Verify funnel experiment charts still render correctly on Day 3 pages
- [ ] Verify GitHub Actions workflows still run successfully (triggered on merge)
- [ ] Confirm no semver range `@0.6/` references remain in codebase
- [ ] Confirm no `@v{N}` version tag references remain in workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)