### PR TITLE
Remove debug SSH key logging and upgrade HTTP links to HTTPS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,11 +177,6 @@ jobs:
         echo "SSH key permissions set"
         
         # Verify key format
-        echo "=== SSH Key Verification ==="
-        echo "Key file size: $(wc -c < ~/.ssh/id_rsa) bytes"
-        echo "First line: $(head -1 ~/.ssh/id_rsa)"
-        echo "Last line: $(tail -1 ~/.ssh/id_rsa)"
-        
         # Test key format
         if ! ssh-keygen -l -f ~/.ssh/id_rsa > /dev/null 2>&1; then
           echo "ERROR: SSH key format is invalid"

--- a/content/days/day-01/02-rediscovered.qmd
+++ b/content/days/day-01/02-rediscovered.qmd
@@ -159,9 +159,9 @@ Store at the Deming Transformation Forum in the UK (<http://www.deming.org.uk>) 
 other Deming-related materials including relevant books and DVDs. The Forum can be contacted for specific advice and assistance including mentoring for individuals and bespoke in-house seminars.
 
 I know of the following long-established and active Deming-based groups in the UK, although there may
-possibly be more. One is the Deming Alliance which began its days as a group within the BDA. The Alliance’s website is <http://www.demingalliance.org> and their meetings are held in the Midlands. The Chartered
+possibly be more. One is the Deming Alliance which began its days as a group within the BDA. The Alliance’s website is <https://www.demingalliance.org> and their meetings are held in the Midlands. The Chartered
 Quality Institute has a Deming Special Interest Group which usually (but not always) meets in London. You
-can reach it by selecting “Community” at <http://www.quality.org> and then “Special Interest Groups (SIGs)”. Also,
+can reach it by selecting “Community” at <https://www.quality.org> and then “Special Interest Groups (SIGs)”. Also,
 the Deming Learning Network (DLN) is based in Scotland with meetings mostly held in Aberdeen. To
 contact the DLN you are welcome to e-mail Tony Miller at <tony@jmiller.co.uk> who can add you to his e-mail
 list for announcements of meetings and for guidance on becoming involved in online participation. I am
@@ -176,7 +176,7 @@ Institute presents various seminars and offers videos including the *Deming Libr
   channel which includes the 1980 NBC White Paper *If Japan Can, Why Can’t We?* (see [page 37](#sec-page37)) that was so
     successful in introducing Dr Deming to the American public in 1980.
     
-Also in America, SPC Press Inc (<http://www.spcpress.com>), who published my book *The Deming Dimension* in
+Also in America, SPC Press Inc (<https://www.spcpress.com>), who published my book *The Deming Dimension* in
     1990 (see pages 12–13 in the Welcome section of file A. PLEASE START HERE), is another excellent
     source for Deming-related publications, materials and seminars. It is also one of the websites that are
     hosting the complete *12 Days to Deming* material.
@@ -191,4 +191,4 @@ Further, some time spent searching the internet is likely to lead you to any num
 FOOTNOTES
 -->
 
-[^a]: Copyright© Deming Prize Committee. All Rights Reserved. <http://www.juse.or.jp/deming_en/>
+[^a]: Copyright© Deming Prize Committee. All Rights Reserved. <https://www.juse.or.jp/deming_en/>

--- a/content/days/day-01/06-outline.qmd
+++ b/content/days/day-01/06-outline.qmd
@@ -117,7 +117,7 @@ of “Obstacles”—which we could regard as “minor diseases”, but diseases
 
 As a relief from the possible gloom to do with diseases, obstacles, and the fact that many managers certainly do *not* regard the 14 Points as “Obligations”, on Day 6 we return to the story-telling mode. The concentration there is on the way a particular company, Gallery Furniture in Houston, Texas, made a huge suc-
 cess of adopting the 14 Points and curing the Deadly Diseases during the 1990s, and of the resulting
-effects on its business. (You might like to check out <http://www.galleryfurniture.com> to see how the company is
+effects on its business. (You might like to check out <https://www.galleryfurniture.com> to see how the company is
 faring all these many years later.)
 
 Hopefully encouraged by that story, we return on Day 7 to many of the problematic matters that are raised


### PR DESCRIPTION
## Summary
- **#17**: Remove 4 lines of SSH key metadata logging from `deploy.yml` that could risk accidental key material exposure via a typo
- **#18**: Upgrade 5 external links to HTTPS where supported (demingalliance.org, quality.org, spcpress.com, juse.or.jp, galleryfurniture.com); 4 links left as HTTP due to no HTTPS support on their servers (deming.org.uk, deming.org, deming.org.in, PriscillaPetty.com)

Closes #17
Closes #18

## Test plan
- [ ] Deploy workflow still succeeds (SSH setup step validates key format without logging content)
- [ ] All 5 updated HTTPS links resolve correctly in rendered site
- [ ] Remaining HTTP links still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)