### PR TITLE
Add rollback docs and WCAG non-color indicators for funnel track

### DIFF
--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -208,23 +208,33 @@ export function renderTrackSVG(currentStage, trackRange) {
     const isTarget = pos === TARGET;
     const inNormalRange = pos >= TRACK_MIN && pos <= TRACK_MAX;
 
-    let fill;
+    let fill, strokeWidth = "1.5", strokeDash = "", stroke = "#333";
+    const isMarble = currentStage && pos === currentStage.marblePos;
+
     if (isTarget) {
-      fill = "#90EE90"; // green for target
+      fill = "#90EE90";
+      strokeWidth = "3";
+      stroke = "#006600";
     } else if (!inNormalRange) {
-      fill = "#d9d9d9"; // grey for extended range
+      fill = "#d9d9d9";
+      strokeDash = ' stroke-dasharray="4,3"';
     } else if (pos % 2 === 0) {
-      fill = "#ffff66"; // yellow
+      fill = "#ffff66";
     } else {
-      fill = "#66cc66"; // green
+      fill = "#66cc66";
     }
 
-    // Highlight marble position
-    if (currentStage && pos === currentStage.marblePos) {
-      fill = "#ff6666"; // red for marble
+    if (isMarble) {
+      fill = "#ff6666";
+      strokeWidth = "3";
+      stroke = "#990000";
     }
 
-    svg += `<rect x="${x}" y="${y}" width="${cellW}" height="${cellH}" fill="${fill}" stroke="#333" stroke-width="1.5"/>`;
+    svg += `<rect x="${x}" y="${y}" width="${cellW}" height="${cellH}" fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth}"${strokeDash}/>`;
+    // Target cell: add a crosshair marker so it's identifiable without color
+    if (isTarget && !isMarble) {
+      svg += `<text x="${x + cellW / 2}" y="${y + 12}" text-anchor="middle" font-size="9" fill="#006600">&#x25C6;</text>`;
+    }
     svg += `<text x="${x + cellW / 2}" y="${y + cellH / 2 + 5}" text-anchor="middle" font-size="14" font-weight="bold">${pos}</text>`;
   }
 

--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -228,10 +228,11 @@ export function renderTrackSVG(currentStage, trackRange) {
       fill = "#ff6666";
       strokeWidth = "3";
       stroke = "#990000";
+      strokeDash = ""; // marble's thick border is sufficient; clear any dash from out-of-range
     }
 
     svg += `<rect x="${x}" y="${y}" width="${cellW}" height="${cellH}" fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth}"${strokeDash}/>`;
-    // Target cell: add a crosshair marker so it's identifiable without color
+    // Target cell: add a diamond marker so it's identifiable without color
     if (isTarget && !isMarble) {
       svg += `<text x="${x + cellW / 2}" y="${y + 12}" text-anchor="middle" font-size="9" fill="#006600">&#x25C6;</text>`;
     }

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,86 @@
+# Deployment Rollback Procedure
+
+Two rollback strategies are available, depending on the situation.
+
+## Option 1: Restore from server-side backup
+
+Every deployment creates a timestamped backup on the server before rsync overwrites the site. Backups are kept at:
+
+```
+www/deming.leedurbin.co.nz/backups/public_html.backup.YYYYMMDDHHMMSS
+```
+
+The five most recent backups are retained automatically.
+
+### Steps
+
+1. SSH into the server:
+
+   ```bash
+   ssh -p 18765 u197-gmrgybn3hkn2@ssh.leedurbin.co.nz
+   ```
+
+2. List available backups (most recent last):
+
+   ```bash
+   ls -1d www/deming.leedurbin.co.nz/backups/public_html.backup.* | sort
+   ```
+
+3. Swap the current site with the chosen backup:
+
+   ```bash
+   DEPLOY=www/deming.leedurbin.co.nz/public_html
+   BACKUP=www/deming.leedurbin.co.nz/backups/public_html.backup.20260403120000  # adjust timestamp
+
+   mv "$DEPLOY" "${DEPLOY}.bad"
+   cp -r "$BACKUP" "$DEPLOY"
+   ```
+
+4. Verify the site loads correctly in a browser.
+
+5. Once confirmed, remove the bad deployment:
+
+   ```bash
+   rm -rf "${DEPLOY}.bad"
+   ```
+
+## Option 2: Re-deploy from a tagged commit
+
+Each successful deployment is tagged `deploy-YYYYMMDDHHMMSS`. To rebuild and deploy from a known-good tag:
+
+### Steps
+
+1. Find the tag to roll back to:
+
+   ```bash
+   git tag --list 'deploy-*' --sort=-creatordate | head -5
+   ```
+
+2. Trigger a workflow run from that tag via the GitHub Actions UI:
+   - Go to **Actions > Build and Deploy (Current) > Run workflow**
+   - Select the tag from the branch/tag dropdown
+
+   Or use the CLI:
+
+   ```bash
+   gh workflow run deploy.yml --ref deploy-20260402150000  # adjust tag
+   ```
+
+3. Monitor the workflow run and verify the site once it completes.
+
+## When to use which
+
+| Scenario | Recommended option |
+|---|---|
+| Bad deployment discovered within minutes | Option 1 (fastest) |
+| Need to revert to a specific older version | Option 2 (rebuild from source) |
+| Server backup has already been rotated out | Option 2 |
+| Suspect build environment issue, not code | Option 1 (avoids rebuilding) |
+
+## Verification
+
+After either rollback method, confirm:
+
+- [ ] Site loads at `deming.leedurbin.co.nz`
+- [ ] Interactive elements (funnel experiment, red beads) function correctly
+- [ ] No console errors in the browser developer tools


### PR DESCRIPTION
## Summary
- **#80**: Created `docs/ROLLBACK.md` with step-by-step procedures for restoring from server-side backups and re-deploying from deployment tags
- **#98**: Added non-color indicators to funnel track SVG cells (WCAG 1.4.1): thick borders for target/marble, dashed borders for out-of-range, diamond marker on target cell

## Test plan
- [ ] `npm test` passes (40 funnel experiment tests)
- [ ] Visually verify funnel track in browser — target cell has thick green border + ◆, marble cell has thick red border, out-of-range cells have dashed borders
- [ ] Desaturate the page (browser DevTools → Rendering → Emulate vision deficiency → Achromatopsia) and confirm all four cell states remain distinguishable
- [ ] Review `docs/ROLLBACK.md` for accuracy against deploy workflow

Closes #80, Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)