### PR TITLE
Add skip-to-content link for keyboard navigation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -78,9 +78,9 @@ format:
     theme: cosmo
     css: assets/styles/main.css
     header-includes: |
-      <a href="#quarto-document-content" class="skip-link">Skip to content</a>
       <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://excalidraw.com; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net;">
       <script src="/assets/scripts/functions.js"></script>
+      <script>document.addEventListener("DOMContentLoaded",function(){var a=document.createElement("a");a.href="#quarto-document-content";a.className="skip-link";a.textContent="Skip to content";document.body.insertBefore(a,document.body.firstChild)});</script>
     number-sections: false
 
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -80,7 +80,15 @@ format:
     header-includes: |
       <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://excalidraw.com; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net;">
       <script src="/assets/scripts/functions.js"></script>
-      <script>document.addEventListener("DOMContentLoaded",function(){var a=document.createElement("a");a.href="#quarto-document-content";a.className="skip-link";a.textContent="Skip to content";document.body.insertBefore(a,document.body.firstChild)});</script>
+      <script>
+        document.addEventListener("DOMContentLoaded", function () {
+          var a = document.createElement("a");
+          a.href = "#quarto-document-content";
+          a.className = "skip-link";
+          a.textContent = "Skip to content";
+          document.body.insertBefore(a, document.body.firstChild);
+        });
+      </script>
     number-sections: false
 
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -78,6 +78,7 @@ format:
     theme: cosmo
     css: assets/styles/main.css
     header-includes: |
+      <a href="#quarto-document-content" class="skip-link">Skip to content</a>
       <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://excalidraw.com; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net;">
       <script src="/assets/scripts/functions.js"></script>
     number-sections: false

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -28,6 +28,8 @@
 }
 .skip-link:focus {
   top: 0;
+  outline: 3px solid #fff;
+  outline-offset: 2px;
 }
 
 /* ===== DESIGN TOKENS ===== */

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -20,7 +20,7 @@
   top: -40px;
   left: 0;
   padding: 8px 16px;
-  z-index: 100;
+  z-index: 1050;
   background: #000;
   color: #fff;
   text-decoration: none;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -14,6 +14,22 @@
   src: url('/assets/fonts/dm-serif-display-italic.woff2') format('woff2');
 }
 
+/* ===== SKIP-TO-CONTENT LINK ===== */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  padding: 8px 16px;
+  z-index: 100;
+  background: #000;
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+}
+.skip-link:focus {
+  top: 0;
+}
+
 /* ===== DESIGN TOKENS ===== */
 :root {
   --color-funnel: #3366cc;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -16,7 +16,7 @@
 
 /* ===== SKIP-TO-CONTENT LINK ===== */
 .skip-link {
-  position: absolute;
+  position: fixed;
   top: -40px;
   left: 0;
   padding: 8px 16px;


### PR DESCRIPTION
## Summary
- Adds a skip-to-content link as the first focusable element on every page, satisfying WCAG 2.4.1 (Bypass Blocks)
- The link is visually hidden off-screen and only appears when focused via keyboard Tab
- Targets `#quarto-document-content` which Quarto already renders as the `<main>` element

Closes #35

## Test plan
- [ ] Run `quarto render` and verify the skip link appears in rendered HTML
- [ ] Open any page in browser, press Tab — "Skip to content" link should appear at top-left
- [ ] Press Enter on the link — focus should move to the main content area
- [ ] Verify the link is not visible during normal mouse browsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)