### PR TITLE
Add ARIA roles to custom callout divs

### DIFF
--- a/assets/templates/chapter-template.qmd
+++ b/assets/templates/chapter-template.qmd
@@ -28,7 +28,7 @@ Content goes here when there's no clock.
 :::: {.columns}
 
 ::: {.column width="85%"}
-<div class=thought_commentary>
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 # PAUSE FOR THOUGHT OR ACTIVITY
 

--- a/content/days/day-01/07-quality-theory.qmd
+++ b/content/days/day-01/07-quality-theory.qmd
@@ -23,9 +23,9 @@ The second mention was in a phrase that I had heard from him time and time again
 
 <span class=deming_quote>“Quality is made at the top.”</span>
 
-<div class=workbook_callout>Pause for Thought 1-a which follows is also (somewhat unsurprisingly!) on [Workbook page 1](workbook.html).</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 1-a which follows is also (somewhat unsurprisingly!) on [Workbook page 1](workbook.html).</div>
 
-<div class=neave_note>The red box indicates there will now be a Pause for Thought or Activity which is immediately followed by
+<div class="neave_note" role="note" aria-label="Author's note">The red box indicates there will now be a Pause for Thought or Activity which is immediately followed by
 some relevant commentary. My commentary will be in the subsequent shaded red box. So always try to
 avoid looking inside the shaded box—just a single sentence in this case—while you’re thinking about
 what the “request for action” is asking you to do. Preferably cover it up with something!</div>
@@ -33,7 +33,7 @@ what the “request for action” is asking you to do. Preferably cover it up wi
 :::: {.columns}
 
 ::: {.column width="85%"}
-<div class=thought_commentary>
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 1-a
 
@@ -68,15 +68,15 @@ And then, as a case in point, Dr Deming’s third and final mention of “qualit
 
 ><span class=deming_quote>“Sure we want good results. But if you manage by results, quality goes down, morale goes down.”</span>
 
-<div class=workbook_callout>The following two Pauses for Thought are also on [Workbook page 2](workbook.html#sec-page2).</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">The following two Pauses for Thought are also on [Workbook page 2](workbook.html#sec-page2).</div>
 
-<div class=neave_note>Unlike a red box, a green box indicates an Activity or Pause for Thought with no associated box of commentary.</div>
+<div class="neave_note" role="note" aria-label="Author's note">Unlike a red box, a green box indicates an Activity or Pause for Thought with no associated box of commentary.</div>
 
 :::: {.columns}
 
 ::: {.column width="85%"}
 
-<div class=thought>
+<div class="thought" role="note" aria-label="Thought">
 ## PAUSE FOR THOUGHT 1-b
 
 Why do you think Dr Deming said that, if you manage by results, both quality and morale go down?
@@ -102,7 +102,7 @@ create_clock(11, 20)
 :::: {.columns}
 
 ::: {.column width="85%"}
-<div class=thought>
+<div class="thought" role="note" aria-label="Thought">
 ## PAUSE FOR THOUGHT 1–c
 
 I well remember a time that I met up with an old acquaintance. I hadn’t seen him for a while, so he

--- a/content/days/day-01/08-attraction.qmd
+++ b/content/days/day-01/08-attraction.qmd
@@ -54,9 +54,9 @@ create_clock(11, 45)
 
 ::::
 
-<div class=workbook_callout>Activity 1-d is also on Workbook page 3.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 1-d is also on Workbook page 3.</div>
 
-<div class=neave_note>Here is an example of a “request for action” that is exceedingly open-ended. You could content yourself
+<div class="neave_note" role="note" aria-label="Author's note">Here is an example of a “request for action” that is exceedingly open-ended. You could content yourself
 by writing some notes on the first few thoughts that come into your mind. Or it could be the subject of a
 number of PhD theses! Since I’m calling this an “Activity” (not even a “*Major* Activity”!) I am indicating
 that my preference lies toward the former of those two extremes!</div>
@@ -64,7 +64,7 @@ that my preference lies toward the former of those two extremes!</div>
 :::: {.columns}
 
 ::: {.column width="85%"}
-<div class=thought>
+<div class="thought" role="note" aria-label="Thought">
 ## ACTIVITY 1-d
 
 Considering the breadth indicated in the title of Dr Deming’s final book: *The New Economics for Industry, Government, Education*, it will be worthwhile for you to spend a little time thinking about the ways
@@ -92,15 +92,15 @@ create_clock(12, 00)
 
 ::::
 
-<div class=workbook_callout>Activity 1-e is also on Workbook page 4.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 1-e is also on Workbook page 4.</div>
 
 :::: {.columns}
 
 ::: {.column width="85%"}
-<div class=thought>
+<div class="thought" role="note" aria-label="Thought">
 ## PAUSE FOR THOUGHT 1–e
 
-<div class=neave_note>This is today’s final Pause for Thought and it goes to the opposite extreme compared with the previous Activity. Here I’m just asking you to consider briefly something very simple in preparation for discussion tomorrow. No calculations, no deep thought—just quickly jot down a couple of opinions for
+<div class="neave_note" role="note" aria-label="Author's note">This is today’s final Pause for Thought and it goes to the opposite extreme compared with the previous Activity. Here I’m just asking you to consider briefly something very simple in preparation for discussion tomorrow. No calculations, no deep thought—just quickly jot down a couple of opinions for
 future reference.</div>
 
 Suppose you are the manager of a telephone call centre. A performance-monitoring scheme is in operation. For each member of staff who is being checked in any particular week, 50 of her callers are
@@ -113,7 +113,7 @@ grim side to start with! How much worse than the average of 10 dissatisfied call
 need to be for you to feel justified in at least cautioning the member of staff concerned: “Watch it! Take
 more care! This isn’t good enough!”? *Any* result worse than average, i.e. 11 or more dissatisfied customers? Actually, it’s not unknown for a person to be criticised if she gets just the 10 dissatisfied customers: after all, using a not-uncommon phrase, that’s “only average”.
 
-<div class=neave_note>Please note that I am not indicating my approval of this or any other such scheme! To criticise people
+<div class="neave_note" role="note" aria-label="Author's note">Please note that I am not indicating my approval of this or any other such scheme! To criticise people
 simply because, according to some set of results, they appear below average or even “only average”
 is, I suggest, a rather dubious judgment mechanism. After all, that means you’re bound to be criticising around half of them even if they are *all* performing brilliantly!</div>
 
@@ -152,7 +152,7 @@ create_clock(12, 10)
 
 ::::
 
-<div class=neave_note>
+<div class="neave_note" role="note" aria-label="Author's note">
 Let me briefly comment on the matter of averages. For in the case of people who cannot understand
 averages, we shall have to work very hard to help them to understand variation!
 

--- a/content/days/day-01/09-different.qmd
+++ b/content/days/day-01/09-different.qmd
@@ -20,7 +20,7 @@ already. (If, like the Japanese did in the 1950s, you become serious about what 
 teach, you will get some short-term benefits, but you should regard them as bonuses rather than
 expectations. To *aim* for them will take your eye off the longer term.)
 
-<div class=neave_note>
+<div class="neave_note" role="note" aria-label="Author's note">
 From the 1990s, Japan (along with some other countries) has, as we know, suffered some economic
 problems. And certain people have pointed to those difficulties and said in effect: “There you are.
 I told you so. This Japan stuff (or quality stuff, or Deming stuff) doesn’t work, does it?”. Two brief
@@ -76,7 +76,7 @@ haven’t yet been addressed will become ever more clear. For otherwise they wil
 :::: {.columns}
 
 ::: {.column width="85%"}
-<div class=neave_note>
+<div class="neave_note" role="note" aria-label="Author's note">
 During these last few years it is notable that, at long last, some attitudes about targets seem to be changing. It was in 2012 that, in a BBC radio interview, I heard a manager talking about getting rid of numerical
 targets. The immediate challenge from the interviewer was “But, without targets, how can you know
 whether or not you are successful?”. (It occurs to me that that question could be worthy of a further

--- a/content/days/day-01/13-major-activity.qmd
+++ b/content/days/day-01/13-major-activity.qmd
@@ -4,7 +4,7 @@ execute:
   echo: false
 ---
   
-<div class=workbook_callout>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">
 Major Activity 1-f (pages 42-44) is also on [Workbook pages 5-7](workbook.html#sec-page5).
 </div>
 

--- a/content/days/day-02/01-run-charts.qmd
+++ b/content/days/day-02/01-run-charts.qmd
@@ -137,9 +137,9 @@ run_chart_plot(c(13, 19, 18, 14, 16, 12, 21, 18, 22))
 
 Now, I repeat that this was just a simple introductory example, purely for illustration to show how easy it is to draw a run chart, i.e. a picture of what otherwise would merely have been just a string of numbers.
 
-<div class=workbook_callout>Pause for Thought 2–a is also on Workbook page 9.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 2–a is also on Workbook page 9.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 2–a
 

--- a/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
+++ b/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
@@ -33,9 +33,9 @@ At least I can say for myself that I had the humility to realise I was missing s
 
 Now, before we get into the details of the Red Beads Experiment, I'll ask you to take some time on a couple of important Pauses for Thought. I wish that, on that occasion in 1985, my mind had been working in the way exemplified in these Pauses for Thought. Maybe then my little grey cells would have been more attuned to what was really going on! Thus my reason for inserting these two Pauses here is to ensure that you are more ready for the learning than I was.
 
-<div class=workbook_callout>Pause for Thought 2–b is also on Workbook page 10.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 2–b is also on Workbook page 10.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 2–b
 
@@ -74,9 +74,9 @@ In his book: *The Discoverers*, Daniel Boorstin wrote as follows:
 
 Your answer to the first of the questions in Pause for Thought 2–b was surely something of the nature of “illusion of knowledge”—it certainly was in my case! So at least note the comforting thought from Daniel Boorstin that this doesn’t imply you or I are, or were, ignorant!
 
-<div class=workbook_callout>Pause for Thought 2–c is also on Workbook page 11.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 2–c is also on Workbook page 11.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 2–c
 

--- a/content/days/day-02/03-a-brief-overview.qmd
+++ b/content/days/day-02/03-a-brief-overview.qmd
@@ -37,9 +37,9 @@ Consequently, the time has come for management to make an impact. A severe but o
 
 The results produced when the experiment was performed at that company in Ireland were as shown on the next page (it is a copy of the Recorder's overhead transparency on that occasion). The recorded numbers are the number of defectives made by each person each week and, as you see, the Recorder (whose name was Declan) adds them up and calculates some averages. On the left side, he wrote each worker's total over the first three weeks: all ready for the appraisal. You will also see that, because of the change to two-shift working in the fourth week, Dec replaced the heading of the final column to refer instead to the second shift in that fourth week.
 
-<div class=workbook_callout>Pause for Thought 2–d (pages 11-12) is also on Workbook pages 12-13.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 2–d (pages 11-12) is also on Workbook pages 12-13.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 2–d
 

--- a/content/days/day-02/04-our-first-control-chart.qmd
+++ b/content/days/day-02/04-our-first-control-chart.qmd
@@ -27,7 +27,7 @@ The second of the two stages which then completes the control chart is to place 
 red_beads_control_chart(c(7, 10, 11, 11, 12, 11, 11, 8, 10, 9, 12, 15, 3, 10, 10, 10, 9, 6, 6, 13, 10, 6, 14, 11), LCL = 1.4, UCL = 18.2)
 ```
 
-<div class="neave_note">
+<div class="neave_note" role="note" aria-label="Author's note">
 If you have classified yourself at Stats-level 1 or above then there will soon be a couple of Technical Aids which will enable you to compute the control limits shown above. If you are at Stats-level 0 then please don't bother with those Technical Aids: just concentrate on what is <em>really</em> important, namely how to <em>interpret</em> the chart and what to deduce from it once it has been drawn. That is what follows here.
 </div>
 
@@ -41,7 +41,7 @@ And then on Day 1 page 33, to emphasise the point, the ninth of the ten Shewhart
 
 Having now seen our first control chart, it won't be difficult for you to guess how it helps us to discriminate between the two states. The simplest guidance (which was pretty much all that Dr Deming gave in his seminars) is that if all the points lie between the two control limits then he would judge the process to be in statistical control (stable). Otherwise the indication is that the process may well be out of statistical control, and so then it could be worthwhile to try to identify special causes: the situations where points go outside the control limits will be good places to start looking.
 
-<div class="neave_note">
+<div class="neave_note" role="note" aria-label="Author's note">
 Now, I rather liken this basic guidance on interpreting a control chart to how you are taught to drive a car in order to pass the official driving test. You obey the speed limits, and you give all the proper signals (whether or not there is anybody behind to see them). However, having passed the test, it is a rare driver who continues to obey all such rules to the letter—indeed, it can be rather annoying for others to be stuck
 behind a vehicle whose driver is doing so!
 As a second illustration, if you have just bought an electrical or petrol-driven tool to use for woodworking
@@ -52,9 +52,9 @@ some of the time. The control chart is also a tool, albeit a statistical tool ra
 
 As a new user of the control chart, here is your obvious Pause for Thought:
 
-<div class=workbook_callout>Pause for Thought 2–e is also on Workbook page 13.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 2–e is also on Workbook page 13.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 2–e
 What does the above control chart tell you?

--- a/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
+++ b/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
@@ -66,7 +66,7 @@ So let us summarise. If the control chart of data from the experiment indicates 
 
 <span class="neave_note"><p>We have now reached the first of the Technical Aids to be included in Days 2 and 3. Here, Technical Aids 1 and 2 describe how the control limits are computed for control charts that are based on the type of data produced and recorded in Red Beads Experiments. Technical Aid 3 contains a warning that, although control limits for all kinds of data are based on similar reasoning, some of the fine detail will vary according to the particular type of data being recorded. Hence the method described here is *not* generally applicable to many other types of data. This matter will be pursued on Day 3.</p> <p>Let me remind you that those who have opted for Stats-level 0 are invited to skip the Technical Aids! Thus, if you have elected to be on Stats-level 0 (or 00), please now move straight on to page 22.</p></span>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 ### Technical Aid 1
 
 One of the earliest applications of Shewhart's invention of the control chart was for batch inspection of mass production processes. In such inspection, samples (batches) of $n$ items from the process's output are regularly drawn and inspected, and the number $X$ of defective items recorded. After several samples have been inspected, the control limits are computed as follows.
@@ -86,11 +86,11 @@ $$
 See if you can use this method to obtain the control limits quoted on page 14 and drawn on page 15. Use all 24 numbers of red beads in your calculation. (If you need help, the computations are sketched out in Technical Aid 2 on the next page—but try it by yourself first in the space at the top of the page or in the Workbook.)
 </div>
 
-<div class=workbook_callout>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">
 Space has also been left for these computations at the top of Workbook page 14.
 </div>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
   <strong>Drawing Pad</strong><br>
   Use the drawing pad below to sketch your formula or diagram. You can download your drawing when finished.
 </div>
@@ -103,7 +103,7 @@ Space has also been left for these computations at the top of Workbook page 14.
   Your browser does not support iframes.
 </iframe>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 ### Technical Aid 2
 
 Firstly, notice that Dec recorded the total number of red beads obtained in the experiment near the bottom right of his table on page 11: it was 235. But now you'll need your calculator.
@@ -117,7 +117,7 @@ So $\overline{X}(1-\overline{p}) = 9.792 \times 0.8042 = 7.8747264$ and $\sqrt{\
 Finally, the distance from $\overline{X}$ out to the two control limits is $3\sqrt{\overline{X}(1-\overline{p})} = 3 \times 2.8062 = 8.419$. This gives the upper and lower control limits as UCL $= \overline{X} + 3\sqrt{\overline{X}(1-\overline{p})} = 9.792 + 8.419 = 18.21$ and LCL $= \overline{X} - 3\sqrt{\overline{X}(1-\overline{p})} = 9.792 - 8.419 = 1.37$.
 </div>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 ### Technical Aid 3
 
 If during Day 1 you read the discussion in the Appendix about the first paradox then you may recall Dr Deming's mention of Shewhart's "3σ-limits" (σ is a Greek letter, pronounced "sigma"). The control limits that you have just computed follow Shewhart's guidance by using $\sigma = \sqrt{\overline{X}(1-\overline{p})}$. The reason for this particular choice when the data come from batch inspection as in the Red Beads Experiment will, I'm afraid, have to be reserved for pages 85–88 in the Optional Extras section.

--- a/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
+++ b/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
@@ -64,7 +64,13 @@ So let us summarise. If the control chart of data from the experiment indicates 
 
 ## The Technical Aids
 
-<span class="neave_note"><p>We have now reached the first of the Technical Aids to be included in Days 2 and 3. Here, Technical Aids 1 and 2 describe how the control limits are computed for control charts that are based on the type of data produced and recorded in Red Beads Experiments. Technical Aid 3 contains a warning that, although control limits for all kinds of data are based on similar reasoning, some of the fine detail will vary according to the particular type of data being recorded. Hence the method described here is *not* generally applicable to many other types of data. This matter will be pursued on Day 3.</p> <p>Let me remind you that those who have opted for Stats-level 0 are invited to skip the Technical Aids! Thus, if you have elected to be on Stats-level 0 (or 00), please now move straight on to page 22.</p></span>
+<div class="neave_note" role="note" aria-label="Author's note">
+
+We have now reached the first of the Technical Aids to be included in Days 2 and 3. Here, Technical Aids 1 and 2 describe how the control limits are computed for control charts that are based on the type of data produced and recorded in Red Beads Experiments. Technical Aid 3 contains a warning that, although control limits for all kinds of data are based on similar reasoning, some of the fine detail will vary according to the particular type of data being recorded. Hence the method described here is *not* generally applicable to many other types of data. This matter will be pursued on Day 3.
+
+Let me remind you that those who have opted for Stats-level 0 are invited to skip the Technical Aids! Thus, if you have elected to be on Stats-level 0 (or 00), please now move straight on to page 22.
+
+</div>
 
 <div class="technical_aid" role="note" aria-label="Technical aid">
 ### Technical Aid 1

--- a/content/days/day-02/06-your-turn.qmd
+++ b/content/days/day-02/06-your-turn.qmd
@@ -7,9 +7,9 @@ I well remember that, the first few times I was preparing to run the Red Beads E
 
 Now comes the time for you to get some practice at playing the role of the Foreman! Remember that the Foreman (pretends that he) is in the Un-Knowing state—typified by all the discussion in the so-called "Analysis" of the results on pages 12 and 13. So, **to help you get ready to perform in that role, I recommend that you now go back and re-read that page and a half before continuing here.**
 
-<div class=workbook_callout>*Activity 2–f (pages 22–27) is also on Workbook pages 14–19.*</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">*Activity 2–f (pages 22–27) is also on Workbook pages 14–19.*</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 2–f
 

--- a/content/days/day-02/07-some-recollections.qmd
+++ b/content/days/day-02/07-some-recollections.qmd
@@ -18,7 +18,7 @@ Two particular runs of the Red Beads Experiment stick in my memory despite the f
 
 If you were still in the Un-Knowing state, you would probably not be at all surprised to learn where these two sets of results originated. Very the best score (a total of just 203 red beads) was obtained by the most elite set of workers I was ever privileged to have participating in the Red Beads Experiment: five departmental heads in the British Government's Central Statistical Office plus one University Professor of Statistics. At the other extreme, the very worst score of 270 red beads was produced on the first of two occasions that I performed the experiment in Madrid, and some people might have doubts about the abilities of Spanish workers. Hold on—*don't take offence at that remark!* The point of this suggestion—and yet a further important message that comes from the Red Beads Experiment—is how easy it is to find data that appear to provide "evidence" to support personal prejudices. Let's take a look at both sets of data.
 
-<div class="neave_note">
+<div class="neave_note" role="note" aria-label="Author's note">
 As with the experiment in Ireland described on pages 9–16, a "performance appraisal" takes place at the end of the third week; the three "worst" workers are then fired and the "best" workers have to work double time during the fourth week—they will need to produce **two** paddles of 50 beads, not just one!
 </div>
 
@@ -51,9 +51,9 @@ It is with those experiences in mind that I'll ask you to take on the role of Fo
 
 There will then remain just two further items on today's agenda. First comes the Major Activity of writing up your comprehensive summary of messages to be learned from the Experiment on Red Beads. So, in preparation for that, keep adding to your list of notes as you now work through the statisticians' and the Spaniards' experiments. Then finally, after the Major Activity, there will be a short Postscript to complete the day.
 
-<div class=workbook_callout>Activity 2–g (pages 32-27) is also on Workbook pages 20-25.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 2–g (pages 32-27) is also on Workbook pages 20-25.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 2–e
 

--- a/content/days/day-02/08-major-activity.qmd
+++ b/content/days/day-02/08-major-activity.qmd
@@ -3,7 +3,7 @@ title: "MAJOR ACTIVITY"
 execute:
   echo: false
 ---
-<div class=workbook_callout>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">
 Major Activity 2-h (pages 38-41) is also on [Workbook pages 26-29](workbook.html#sec-page5).
 </div>
 

--- a/content/days/day-03/01-variation-the-enemy-of-quality.qmd
+++ b/content/days/day-03/01-variation-the-enemy-of-quality.qmd
@@ -41,9 +41,9 @@ Next, as promised on Day 1, here is a rather longer extract from Dr Deming's acc
 
 Unexpected as it might be, it seems that Dr Deming first used the terms "common cause" and "special cause" around 1947 in discussions on *prison riots* (see *Out of the Crisis* page 270(pages 314–315)). Did something *special* occur to spark off a riot? Or was the riot due to the procedures, the environment, the morale of both the prisoners and the prison staff, the way the staff treated the prisoners, etc, etc? That is, was the *common* state of affairs (which Deming would refer to as the system) in the prison such that riots would be *bound* to occur from time to time? (Think back to Day 1's Major Activity.) Or would it take something special?
 
-<div class="workbook_callout">Activity 3–a is also on Workbook page 31.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–a is also on Workbook page 31.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 3–a
 
@@ -68,9 +68,9 @@ Being guided by the thoughts about prison riots, factors which result in somewha
 </div>
 </div>
 
-<div class="workbook_callout">Activity 3–b is also on Workbook page 32.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–b is also on Workbook page 32.</div>
 
-<div class="thought">
+<div class="thought" role="note" aria-label="Thought">
 
 ## ACTIVITY 3–b
 

--- a/content/days/day-03/02-at-the-ford-motor-company.qmd
+++ b/content/days/day-03/02-at-the-ford-motor-company.qmd
@@ -17,9 +17,9 @@ A statistician recommended that the next 50 shafts should be made with the compe
 
 Reduced variation! Better quality! Everything clearly within the specifications! *With that sensible and very expensive compensation device turned off!*
 
-<div class="workbook_callout">Activity 3–c is also on Workbook page 33.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–c is also on Workbook page 33.</div>
 
-<div class="thought">
+<div class="thought" role="note" aria-label="Thought">
 
 ## ACTIVITY 3–c
 

--- a/content/days/day-03/03-the-importance-of-time.qmd
+++ b/content/days/day-03/03-the-importance-of-time.qmd
@@ -13,9 +13,9 @@ Here are two forms of histogram of those data. On the left, each item in the dat
 
 ![Two histograms of the same 24 values ranging from 10 to 19: on the left, individual boxes stacked to show frequency; on the right, a conventional bar histogram. Both show a roughly symmetric distribution peaking at 13 with four occurrences](/assets/images/day-03/two-histograms-24-values.png){fig-align="center" width="90%" .lightbox}
 
-<div class="workbook_callout">Activity 3–d is also on Workbook page 34.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–d is also on Workbook page 34.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 3–d
 
@@ -42,9 +42,9 @@ Just to be sure, let's draw run charts of the data. Here is a run chart for the 
 
 ![Run chart of the first process](/assets/images/day-03/run-chart-first-process.png){fig-align="center" width="80%" .lightbox}
 
-<div class="workbook_callout">Activity 3–e (pages 8–9) is also on Workbook page 35.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–e (pages 8–9) is also on Workbook page 35.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 3–e
 

--- a/content/days/day-03/04-more-on-the-sales-data.qmd
+++ b/content/days/day-03/04-more-on-the-sales-data.qmd
@@ -23,9 +23,9 @@ run_chart_plot(c(13, 19, 18, 14, 16, 12, 21, 18, 17, 22))
 
 First, a short Pause for Thought:
 
-<div class="workbook_callout">Pause for Thought 3–f is also on Workbook page 36.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 3–f is also on Workbook page 36.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 3–f
 

--- a/content/days/day-03/05-how-do-we-compute-control-limits.qmd
+++ b/content/days/day-03/05-how-do-we-compute-control-limits.qmd
@@ -61,13 +61,13 @@ On the other hand, if you find it too difficult to deal with everything in the t
 
 So, if you are on Stats-level 0 (or 00), please omit the following Technical Aids and move on to page 19.
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 ## Technical Aid 5
 
 With Red Beads and similar data, the σ in Shewhart's guidance for control limits (referred to on Appendix page 4) was computed by a formula merely involving the average: $\bar{X}$. That was possible because, with such data, there is a natural link between the average and the way the data vary. (If the average is particularly small or large then the variation is relatively small, whereas if the average is more central then the variation is relatively large.) This is not the case with most other types of data, and so then a more direct representation of the variation is needed. As has now been introduced, the recommended method uses moving ranges: the distances (positive or zero, not negative) between consecutive values in the data.
 </div>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 ## Technical Aid 6
 
 The artificial sales data on pages 10–12 were, in time order: 13&ensp;19&ensp;18&ensp;14&ensp;16&ensp;12&ensp;21&ensp;18&ensp;17&ensp;22.
@@ -87,7 +87,7 @@ So $\overline{MR} = (6 + 1 + 4 + 2 + 4 + 9 + 3 + 1 + 5) \div 9 = 35 \div 9 = 3.8
 (c) The control limits are placed at a distance of $2.66 \times \overline{MR}$ either side of the Central Line. Here we have $2.66 \times \overline{MR} = 2.66 \times 3.889 = 10.34$, and so the control limits were placed at $17.0 - 10.34 = 6.7$ and at $17.0 + 10.34 = 27.3$.
 </div>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 ## Technical Aid 7
 
 Why the 2.66? Sorry: as with the formula in the Red Beads case, this is more material for the Optional Extras. But trust me: it is derived using the guidance about control limits provided by Dr Shewhart.
@@ -95,7 +95,7 @@ Why the 2.66? Sorry: as with the formula in the Red Beads case, this is more mat
 However, although moving ranges are quick and easy to compute, they can become quite tedious if being computed (especially by hand) for a lot of data. For example, it would be bad enough if we had to compute control limits using all the 24 data in the illustration below. Much worse still would be control limits for the data which you will generate in this afternoon's Major Activity: four lots of 40 numbers!
 </div>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 ## Technical Aid 8
 
 If we want to turn run charts containing a lot of data into control charts, do we have to use all those data to compute the control limits?
@@ -125,9 +125,9 @@ So $\overline{MR} = (1 + 1 + 0 + 1 + 1 + 2 + 0 + 1 + 1 + 1 + 1) \div 11 = 10 \di
 
 This was clearly a case where, in practice, there was little to be gained by producing the control chart: the run chart had already told the story of the rising trend. That's fine: if the run chart tells you all you need to know then don't bother to upgrade it to a control chart. The control chart becomes really valuable when it is unclear as to whether or not the run chart is indicating there are some special causes—which is the more usual situation.
 
-<div class="workbook_callout">Activity 3–g is also on Workbook page 37.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–g is also on Workbook page 37.</div>
 
-<div class="thought">
+<div class="thought" role="note" aria-label="Thought">
 
 ## ACTIVITY 3–g
 

--- a/content/days/day-03/08-control-chart-and-brain.qmd
+++ b/content/days/day-03/08-control-chart-and-brain.qmd
@@ -25,7 +25,7 @@ You may recall that the Ford histograms on page 5 showed the positions of Lower 
 
 Further weight to the above argument comes from the fact that, even if a process remains blissfully in statistical control, control limits computed from two different sets of data from that stable process are almost bound to be different from each other. Data vary: thus so will control limits. So if other control limits are computed from different data from that same stable process, the strong likelihood is that the particular two points considered in the previous paragraph will now either be *both* below the new UCL or *both* above it—making it even more illogical to act completely differently depending on which of the two you have.
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 
 ## Technical Aid 9
 

--- a/content/days/day-03/09-the-six-processes-revisited.qmd
+++ b/content/days/day-03/09-the-six-processes-revisited.qmd
@@ -59,7 +59,7 @@ Lastly, although we have been using Charts A3–F3 in this discussion, do not fo
 
 As you can see, all we have left on this page is a couple of Technical Aids. So if you are on Stats-level 0 then please move straight on to page 35.
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 
 ## Technical Aid 10
 
@@ -70,7 +70,7 @@ I might already be so convinced of the trend that I would start searching for it
 Thus (presuming the process is one over which you have some influence) your need is to try to identify and deal with the special cause(s) of whose presence you have now been made aware. After you have taken appropriate action to try to stabilise the process, then (as in the Tokai Rika case study, Process E) you would resume recording data and, in due course, recompute the control limits. You are thus "back to Square 1": extending those control limits into the future if the process is now in statistical control or else resuming your search for special causes if it isn't.
 </div>
 
-<div class="technical_aid">
+<div class="technical_aid" role="note" aria-label="Technical aid">
 
 ## Technical Aid 11
 

--- a/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
+++ b/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
@@ -39,7 +39,7 @@ We'll use my own dice-scores to start with so that you can follow my illustratio
 
 **Use the interactive below to step through Rule 2.** The first 5 stages use the author's worked example (dice-scores 10, 8, 6, 7, 4); from Stage 6 onward your own randomly-generated dice are used.
 
-<div class="workbook_callout">This table is also on Workbook pages 38–39.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">This table is also on Workbook pages 38–39.</div>
 
 ```{ojs}
 //| output: false
@@ -159,7 +159,7 @@ In this case where you don't move the funnel at all, you may be able to stop usi
 
 As you can see, with Ford's Second Strategy (Rule 1) you also no longer need the two rows which were under each yellow-shaded row in the Ford's First Strategy (Rule 2) version of the book-keeping (see page 42 and then your table on page 44 *[WB 38–39]*): they were only there to work out where that strategy (Rule 2) would move the funnel. Now, of course, the funnel stays put at 30. So, with everything being so much simpler than before, I think you'll find it very easy to do the book-keeping this time!
 
-<div class="workbook_callout">This table is also on Workbook page 40.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">This table is also on Workbook page 40.</div>
 
 ```{ojs}
 //| output: false

--- a/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
+++ b/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
@@ -33,7 +33,7 @@ And so on. The fourth and fifth dice-scores were 7 and 4 corresponding respectiv
 
 Just for interest, take a moment's thought to guess what will happen in the long term as you take Rule 3 through its 40 stages. Then, later on, see if you've guessed correctly!
 
-<div class="workbook_callout">Pages 50–51 are also on Workbook pages 42–43.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pages 50–51 are also on Workbook pages 42–43.</div>
 
 ```{ojs}
 //| output: false
@@ -163,7 +163,7 @@ So off you go for the final time. Again if you didn't do so when I first suggest
 
 Rule 4 is one of the easier strategies to carry out, so you can stop using your track as soon as you realise you don't need it any more. That may be very soon!
 
-<div class="workbook_callout">Pages 54–55 are also on Workbook pages 44–45.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pages 54–55 are also on Workbook pages 44–45.</div>
 
 ```{ojs}
 //| output: false

--- a/content/days/day-03/13-summary.qmd
+++ b/content/days/day-03/13-summary.qmd
@@ -150,9 +150,9 @@ summaryR4 = runAllStages(4, diceSeqSummary)
 
 <div class="separator_blue"></div>
 
-<div class="workbook_callout">Activity 3–i is also on Workbook page 46.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–i is also on Workbook page 46.</div>
 
-<div class="thought">
+<div class="thought" role="note" aria-label="Thought">
 
 ## ACTIVITY 3–i
 
@@ -190,9 +190,9 @@ Reveal suggested answer for Activity 3-i
 </div>
 </div>
 
-<div class="workbook_callout">Activity 3–j is also on Workbook page 47.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 3–j is also on Workbook page 47.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 3–j
 

--- a/content/days/day-04/02-the-joiner-triangle.qmd
+++ b/content/days/day-04/02-the-joiner-triangle.qmd
@@ -7,11 +7,11 @@ execute:
 
 Going right back to Dr Shewhart's formative work in the 1920s, we know that the vital thing to always bear in mind is the division of variation into its two types, coupled with the observation by Dr Deming and others that by far the more important and more numerous problems (and therefore opportunities for improvement) primarily lie in the common causes of variation, i.e. in the system. What sort of things might these include? There is, for instance, a host of them which relate directly to the company or organisation as a whole: its "culture", its rules and principles, the reward and punishment mechanisms, the nourishment or discouragement of innovation, whether people are regarded as having real brains or just as "black boxes", etc, etc. The issue of variation is, of course, all highly related to work we have already done, e.g. in our learning from the Experiment on Red Beads and the issue of "tampering", so well illustrated in the Funnel Experiment.
 
-<div class="neave_note">My friend Malcolm Gall once pointed out to me that a "Scientific Approach"—which I suppose might be interpreted as something like a "Purely Logical Approach"—may be seen by some as an inhibitor of creativity and innovation (to be studied on Day 9). On Day 11, I shall suggest further topics that have a place in such an approach, some of which look ahead to Day 11 and in particular to the "Theory of Knowledge" aspects of Deming's teaching. In Malcolm's words, innovators "need to understand the role of theory and test"—for intelligent innovators must agree that otherwise some of their innovations might not work! In fact, a Scientific Approach supports and aids creativity in practice by helping to discern whether innovations will or will not work and, in the latter case, can provide help in modifying them so that they will work.</div>
+<div class="neave_note" role="note" aria-label="Author's note">My friend Malcolm Gall once pointed out to me that a "Scientific Approach"—which I suppose might be interpreted as something like a "Purely Logical Approach"—may be seen by some as an inhibitor of creativity and innovation (to be studied on Day 9). On Day 11, I shall suggest further topics that have a place in such an approach, some of which look ahead to Day 11 and in particular to the "Theory of Knowledge" aspects of Deming's teaching. In Malcolm's words, innovators "need to understand the role of theory and test"—for intelligent innovators must agree that otherwise some of their innovations might not work! In fact, a Scientific Approach supports and aids creativity in practice by helping to discern whether innovations will or will not work and, in the latter case, can provide help in modifying them so that they will work.</div>
 
-<div class="workbook_callout">Activity 4–a (pages 4–5) is also on Workbook pages 49–50.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 4–a (pages 4–5) is also on Workbook pages 49–50.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 4–a
 
@@ -57,11 +57,11 @@ viewof activity_4a_3 = Inputs.textarea({
 
 The words "All One Team" surely speak for themselves. They have strong connections with the concepts of optimisation of the system (i.e. helping it to work in the best-possible way) and of "Cooperation: Win-Win". We have mentioned both of these in the Overture and will cover them in greater depth later on.
 
-<div class="neave_note">Some senior managers worry that heading toward "All One Team" might pose a threat to their authority. However, a further astute observation from Malcolm Gall is that "Interdependence is not an indication of weakness, but an indication of maturity".</div>
+<div class="neave_note" role="note" aria-label="Author's note">Some senior managers worry that heading toward "All One Team" might pose a threat to their authority. However, a further astute observation from Malcolm Gall is that "Interdependence is not an indication of weakness, but an indication of maturity".</div>
 
-<div class="workbook_callout">Activity 4–b (pages 6–7) is also on Workbook pages 51–52.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 4–b (pages 6–7) is also on Workbook pages 51–52.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 4–b
 
@@ -98,7 +98,7 @@ In all fields of activity, everyone recognises the importance of quality *to a c
 
 Two particular problems with this attitude to quality are as follows (wherever the specifications originate). First, having worked to reach the standard or target or specification, etc, there is often a tendency to breathe a sigh of relief—one of the most natural things in the world for the time being. The other problem, which we'll address later (e.g. when working on the 11th of the 14 Points), is the temptation to try to "cheat" in order to *appear* to meet the requirements. Deming often spoke disparagingly about "fudging figures" (to be discussed later) as redefining methods of measurement—so what exactly qualifies for descriptions such as "punctual" or "defective"? (The work on operational definitions on Day 11 will be very relevant here.)
 
-<div class="neave_note">Because the notion of assessing quality in terms of conformance to specifications is so widespread, some may find Deming's teaching on this matter to be particularly challenging. Of course, he is not suggesting that there's nothing to be gained from meeting specifications! His message is instead neatly summarised by the phrase <span class="deming_quote">"Specifications, meeting specifications not sufficient"</span> that appears in *Out of the Crisis*'s index (page 428[505]) and points to several references to relevant material in the book.
+<div class="neave_note" role="note" aria-label="Author's note">Because the notion of assessing quality in terms of conformance to specifications is so widespread, some may find Deming's teaching on this matter to be particularly challenging. Of course, he is not suggesting that there's nothing to be gained from meeting specifications! His message is instead neatly summarised by the phrase <span class="deming_quote">"Specifications, meeting specifications not sufficient"</span> that appears in *Out of the Crisis*'s index (page 428[505]) and points to several references to relevant material in the book.
 
 But since the customer or the Government etc may be, or may become, aware of such attempts to "cheat", would it not be more advisable to improve quality in order to prevent the negative consequences of not so doing? Even then, this could merely be referred to as an obsession with quality. "Obsession" is much more indicative of *continual* improvement, making quality a "way of life", etc—whether or not there appears to be any vital and immediate *need* to do so. And there's the difference. Everyone appreciates the highly *negative* effects of *poor* quality—and, the poorer the quality, the more negative the effects. But Dr Deming was trying to get us to equally appreciate the highly *positive* effects of *good* quality—and, the better the quality, the more positive the effects.
 
@@ -108,9 +108,9 @@ I recall two occasions in four-day seminars when the topic of "quality tools" wa
 
 However, as Brian did also include "statistical thinking" and "special and common causes" in his selection of topics, and so presumably "charting" definitely included the control chart! It seems wise for the current purposes to restrict our attention for most of the project which follows to the charting introduced by both Drs Shewhart and Deming via our opening day and about which we have now learned plenty during Days 2 and 3. This will also be ideal preparation for the Second Project on Days 10 and 11 which involves the System of Profound Knowledge (briefly introduced on Day 1 page 37) since "Understanding Variation" is one of the latter's four component parts.</div>
 
-<div class="workbook_callout">Pause for Thought 4–c is also on Workbook page 53.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 4–c is also on Workbook page 53.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## PAUSE FOR THOUGHT 4–c
 
@@ -144,9 +144,9 @@ To people who have always thought of "quality" in terms of specifications, targe
 
 But is it really beyond rhyme and reason to think of improving quality to the extent of *delighting* the customer? In asking the question "Can we afford to delight the customer?", might it not be more important in many instances to change the emphasis to: "Can we afford *not* to delight the customer?"
 
-<div class="workbook_callout">Activity 4–d is also on Workbook page 54.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Activity 4–d is also on Workbook page 54.</div>
 
-<div class="thought_commentary">
+<div class="thought_commentary" role="note" aria-label="Commentary">
 
 ## ACTIVITY 4–d
 

--- a/content/days/day-04/04-points-1-to-6.qmd
+++ b/content/days/day-04/04-points-1-to-6.qmd
@@ -3,7 +3,7 @@ title: "POINTS 1–6"
 execute:
   echo: false
 ---
-<div class="workbook_callout">Points 1–6 (pages 16–27) are also on Workbook pages 51–67.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Points 1–6 (pages 16–27) are also on Workbook pages 51–67.</div>
 
 ---
 
@@ -59,7 +59,7 @@ This is a whole new philosophy. It's not just optional add-ons to what we are al
 
 This Point illuminates the danger of just "making do". The implication is that we may have become so used to lower levels of product and service that we have become resigned to them and skilled in compensating for them. But that might not be so true of your customer.
 
-<div class="neave_note">The reason for the description "created in Japan" which Deming included in the statement of this Point may be less obvious now than when he said it in the 1980s. At that time, Japan unarguably led the world in terms of quality and reliability. But even then I puzzled about the fact that the Japanese were seemingly unaware of what was happening in their own country! Deming taught in Japan during the 1950s, but there were certainly no four-day seminars there. I doubt whether many Japanese knew much about what was teaching elsewhere during the first ten years or so of his life. I sometimes muse on the thought that perhaps, if they had, some of the difficulties subsequently experienced by their country might have been avoided. Recall my note in the middle of Day 1 page 27.</div>
+<div class="neave_note" role="note" aria-label="Author's note">The reason for the description "created in Japan" which Deming included in the statement of this Point may be less obvious now than when he said it in the 1980s. At that time, Japan unarguably led the world in terms of quality and reliability. But even then I puzzled about the fact that the Japanese were seemingly unaware of what was happening in their own country! Deming taught in Japan during the 1950s, but there were certainly no four-day seminars there. I doubt whether many Japanese knew much about what was teaching elsewhere during the first ten years or so of his life. I sometimes muse on the thought that perhaps, if they had, some of the difficulties subsequently experienced by their country might have been avoided. Recall my note in the middle of Day 1 page 27.</div>
 
 ### Obsession With Quality
 
@@ -113,7 +113,7 @@ Despite Dr Deming's particular wording here, the lessons from this Point relate 
 
 An Obsession With Quality will surely result in quality being improved way beyond that which needs mass inspection to verify it. Notice again the words "the need for". Deming isn't simply saying "Stop doing it". He is telling us to improve things so that mass inspection becomes redundant.
 
-<div class="neave_note">There are more general practical lessons to learn from this observation. If you're interested, take a quick look at the final paragraph on Appendix page 23.</div>
+<div class="neave_note" role="note" aria-label="Author's note">There are more general practical lessons to learn from this observation. If you're interested, take a quick look at the final paragraph on Appendix page 23.</div>
 
 ```{ojs}
 viewof p3_owq = Inputs.textarea({
@@ -209,7 +209,7 @@ Here we have a direct contradiction to a familiar saying—and maybe a familiar 
 
 We have already pointed out that Deming was talking about quality "across the board"—quality of the end-product or service, of course, but quality of all that contributes to delivering that product or service. This link is therefore particularly strong.
 
-<div class="neave_note">An objection to Point 5 sometimes heard from those who are not yet in tune with what Deming was teaching is that "we can't afford to keep improving". It comes from those who think that improvement can only be achieved expensively by bringing in more consultants, etc, etc. But, to put it mildly, these were not Deming's focus on improvement. His emphasis was instead on reducing costs, particularly through improvement of processes and reducing variation—such improvements are frequently very inexpensive yet can produce considerable rewards. For confirmation, again refer back to his Chain Reaction (*DemDim* page 33).</div>
+<div class="neave_note" role="note" aria-label="Author's note">An objection to Point 5 sometimes heard from those who are not yet in tune with what Deming was teaching is that "we can't afford to keep improving". It comes from those who think that improvement can only be achieved expensively by bringing in more consultants, etc, etc. But, to put it mildly, these were not Deming's focus on improvement. His emphasis was instead on reducing costs, particularly through improvement of processes and reducing variation—such improvements are frequently very inexpensive yet can produce considerable rewards. For confirmation, again refer back to his Chain Reaction (*DemDim* page 33).</div>
 
 ```{ojs}
 viewof p5_owq = Inputs.textarea({
@@ -259,7 +259,7 @@ Training budgets in many organisations are absurdly small. So how do people lear
 
 Clearly, a prerequisite for people to do quality work is that they have received appropriate training for that work and can understand it. Notice that here Deming is at pains to emphasise the particular relevance of this to management. He is quite clearly considered, and often said, that potential managers do not learn it in most MBA courses.
 
-<div class="neave_note">As a personal viewpoint regarding training, I think it may be insufficient to simply pick off some to some external consultants' training course, however excellent it may appear to be. I have seen both of these happen to be true of training—whether it is good or bad. I think, perhaps, the first of these is usually more true of training external than internal: "People learn in different ways". Person A may respond better than Person B to a particular method of training. This is equally true with another method of training: again this is likely to be far better catered for in-house than externally.</div>
+<div class="neave_note" role="note" aria-label="Author's note">As a personal viewpoint regarding training, I think it may be insufficient to simply pick off some to some external consultants' training course, however excellent it may appear to be. I have seen both of these happen to be true of training—whether it is good or bad. I think, perhaps, the first of these is usually more true of training external than internal: "People learn in different ways". Person A may respond better than Person B to a particular method of training. This is equally true with another method of training: again this is likely to be far better catered for in-house than externally.</div>
 
 ```{ojs}
 viewof p6_owq = Inputs.textarea({
@@ -285,7 +285,7 @@ viewof p6_aot = Inputs.textarea({
 
 Here it is appropriate to recall the original expanded version of the Joiner Triangle on page 11 in addition to my subsequent suggested modification. As we saw, Joiner Associates' own expanded version of the Triangle included flowcharting and other "old tools" of quality under the Scientific Approach. Obviously, the control chart is in both versions!
 
-<div class="neave_note">**NB** My alternative list of topics for the Scientific Approach on page 12 was not intended as a criticism of the original expanded Joiner Triangle! Regarding the difference in nature between education and training: consultants in the Deming area clearly need to work with both, and thus the version of the Scientific Approach on page 11 was entirely appropriate for Joiner Associates. But, equally clearly, the primary nature of *12 Days to Deming* is education, and so a different emphasis regarding the Scientific Approach is usually appropriate here.</div>
+<div class="neave_note" role="note" aria-label="Author's note">**NB** My alternative list of topics for the Scientific Approach on page 12 was not intended as a criticism of the original expanded Joiner Triangle! Regarding the difference in nature between education and training: consultants in the Deming area clearly need to work with both, and thus the version of the Scientific Approach on page 11 was entirely appropriate for Joiner Associates. But, equally clearly, the primary nature of *12 Days to Deming* is education, and so a different emphasis regarding the Scientific Approach is usually appropriate here.</div>
 
 ```{ojs}
 viewof p6_sa = Inputs.textarea({

--- a/content/days/day-05/02-points-7-to-14.qmd
+++ b/content/days/day-05/02-points-7-to-14.qmd
@@ -3,7 +3,7 @@ title: "POINTS 7–14"
 execute:
   echo: false
 ---
-<div class="workbook_callout">Points 7–12 (pages 2–13) are also on Workbook pages 70–81.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Points 7–12 (pages 2–13) are also on Workbook pages 70–81.</div>
 
 ---
 
@@ -21,7 +21,7 @@ Particularly with reference to All One Team, my friend Dave Kerr wrote to me as 
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 7 (pages 2–3) is also on Workbook pages 70–71.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 7 (pages 2–3) is also on Workbook pages 70–71.</div>
 
 ```{ojs}
 viewof p7_owq = Inputs.textarea({
@@ -81,7 +81,7 @@ In Point 12 we shall find Dr Deming talking of the value of "pride of workmanshi
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 8 (pages 4–5) is also on Workbook pages 72–73.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 8 (pages 4–5) is also on Workbook pages 72–73.</div>
 
 ```{ojs}
 viewof p8_owq = Inputs.textarea({
@@ -157,7 +157,7 @@ Holmes was speaking to the Sales Director, Peter Marks.
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 9 (pages 6–7) is also on Workbook pages 74–75.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 9 (pages 6–7) is also on Workbook pages 74–75.</div>
 
 ```{ojs}
 viewof p9_owq = Inputs.textarea({
@@ -219,7 +219,7 @@ If something so shallow as alluded to in this Point could have any positive effe
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 10 (pages 8–9) is also on Workbook pages 76–77.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 10 (pages 8–9) is also on Workbook pages 76–77.</div>
 
 ```{ojs}
 viewof p10_owq = Inputs.textarea({
@@ -281,7 +281,7 @@ Resources are channelled into reaching that number, irrespective of the harm cau
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 11 (pages 10–11) is also on Workbook pages 78–79.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 11 (pages 10–11) is also on Workbook pages 78–79.</div>
 
 ```{ojs}
 viewof p11_owq = Inputs.textarea({
@@ -339,7 +339,7 @@ The matter of performance appraisal itself is the subject of the third of the De
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 12 (pages 12–13) is also on Workbook pages 80–81.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 12 (pages 12–13) is also on Workbook pages 80–81.</div>
 
 ```{ojs}
 viewof p12_owq = Inputs.textarea({
@@ -383,7 +383,7 @@ create_clock(12, 0)
 
 ::::
 
-<div class="workbook_callout">Points 13–14 (pages 14–17) are also on Workbook pages 82–85.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Points 13–14 (pages 14–17) are also on Workbook pages 82–85.</div>
 
 ---
 
@@ -413,7 +413,7 @@ Point 13 implies far more than might be noticed at first glance.
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 13 (pages 14–15) is also on Workbook pages 82–83.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 13 (pages 14–15) is also on Workbook pages 82–83.</div>
 
 ```{ojs}
 viewof p13_owq = Inputs.textarea({
@@ -469,7 +469,7 @@ create_clock(12, 0)
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Point 14 (pages 16–17) is also on Workbook pages 84–85.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Point 14 (pages 16–17) is also on Workbook pages 84–85.</div>
 
 ```{ojs}
 viewof p14_owq = Inputs.textarea({

--- a/content/days/day-05/03-the-deadly-diseases.qmd
+++ b/content/days/day-05/03-the-deadly-diseases.qmd
@@ -9,7 +9,7 @@ Now it's time to take a break to watch the video *Management's Five Deadly Disea
 
 ---
 
-<div class="workbook_callout">The "Five Deadly Diseases" (pages 18–27) are also on Workbook pages 86–95.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">The "Five Deadly Diseases" (pages 18–27) are also on Workbook pages 86–95.</div>
 
 ---
 
@@ -27,7 +27,7 @@ It is relevant here to point out the error in a phrase glibly trotted out by man
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Disease 1 (pages 18–19) is also on Workbook pages 86–87.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Disease 1 (pages 18–19) is also on Workbook pages 86–87.</div>
 
 ```{ojs}
 viewof d1_owq = Inputs.textarea({
@@ -91,7 +91,7 @@ This will be so familiar to many readers that I need say no more.
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Disease 2 (pages 20–21) is also on Workbook pages 88–89.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Disease 2 (pages 20–21) is also on Workbook pages 88–89.</div>
 
 ```{ojs}
 viewof d2_owq = Inputs.textarea({
@@ -155,7 +155,7 @@ It may be wise at this stage for me to remind you of my warning at the bottom of
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Disease 3 (pages 22–23) is also on Workbook pages 90–91.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Disease 3 (pages 22–23) is also on Workbook pages 90–91.</div>
 
 ```{ojs}
 viewof d3_owq = Inputs.textarea({
@@ -215,7 +215,7 @@ Moving around the organisation in order to acquire that broader understanding is
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Disease 4 (pages 24–25) is also on Workbook pages 92–93.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Disease 4 (pages 24–25) is also on Workbook pages 92–93.</div>
 
 ```{ojs}
 viewof d4_owq = Inputs.textarea({
@@ -279,7 +279,7 @@ In conclusion, and back to the main issue (from *Out of the Crisis* pages 104–
 
 ### Obsession With Quality
 
-<div class="workbook_callout">Disease 5 (pages 26–27) is also on Workbook pages 94–95.</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Disease 5 (pages 26–27) is also on Workbook pages 94–95.</div>
 
 ```{ojs}
 viewof d5_owq = Inputs.textarea({
@@ -289,7 +289,7 @@ viewof d5_owq = Inputs.textarea({
 })
 ```
 
-<div class="neave_note">**NB** There may be a potential danger in using the summary on the previous page without clarification: it is a possible misunderstanding of the term "work standards". But we only have to refer back to Point 11 (page 10): "work standards that prescribe quotas for the workforce and numerical goals for people in management" to be clear about Deming's focus with those words. That focus is, of course, in no way related to e.g. *standardising* work, procedures, operations, etc once they have been found advantageous. Apart from anything else, this clearly reduces variation. Some refer to these more appropriate practices by alternative terms such as "standard work" which helps to avoid possible ambiguity.</div>
+<div class="neave_note" role="note" aria-label="Author's note">**NB** There may be a potential danger in using the summary on the previous page without clarification: it is a possible misunderstanding of the term "work standards". But we only have to refer back to Point 11 (page 10): "work standards that prescribe quotas for the workforce and numerical goals for people in management" to be clear about Deming's focus with those words. That focus is, of course, in no way related to e.g. *standardising* work, procedures, operations, etc once they have been found advantageous. Apart from anything else, this clearly reduces variation. Some refer to these more appropriate practices by alternative terms such as "standard work" which helps to avoid possible ambiguity.</div>
 
 ### All One Team
 

--- a/index.qmd
+++ b/index.qmd
@@ -422,7 +422,7 @@ One thing at a time. Let’s first deal with moving to and from the Workbook.
 The time to transfer to the Workbook is signalled in the main material by a yellow information box such as
 the following example which you will see at the top of Day 1 page 25, just above Pause for Thought 1–e:
 
-<div class="workbook_callout">
+<div class="workbook_callout" role="note" aria-label="Workbook reference">
 Pause for Thought 1-e is also on Workbook page 4.
 </div>
 
@@ -430,7 +430,7 @@ Obviously, if you have chosen not to use the Workbook, you will simply ignore th
 with all other references to the Workbook elsewhere) and proceed with that Pause for Thought right there
 on Day 1 page 25. Otherwise you should turn to Workbook page 4 where you will be greeted by a corresponding yellow information box which confirms your safe arrival at the correct location:
 
-<div class="workbook_callout">
+<div class="workbook_callout" role="note" aria-label="Workbook reference">
 Pause for Thought 1-e comes from Day 1 page 25.
 </div>
 
@@ -518,7 +518,7 @@ demand on your time, although that time is organised rather differently.
 
 And, of course, I will not be setting you an exam! By the end of these 12 days, you won’t need one.
 
-<div class="neave_note">
+<div class="neave_note" role="note" aria-label="Author's note">
 Just in case 12 days still sounds rather ambitious to you, there is an alternative. This course happens to
 divide naturally into two halves, Days 1–6 and Days 7–12, which have rather different natures and contents. In terms of college or university courses, Days 1–6 could be regarded as an undergraduate course
 followed by Days 7–12 as a postgraduate course. Or, thinking of one’s younger days, Days 1–6 could be
@@ -587,7 +587,7 @@ can print out and write on during all the activities. As also mentioned in that 
 happy to mostly read material on-screen rather than on printed copy, the Workbook is *all* that you will ever
 need to print out.
 
-<div class="neave_note">
+<div class="neave_note" role="note" aria-label="Author's note">
 **NB** If your screen is insufficiently large and/or you are using an oldish version of the Adobe Acrobat software then just a few (but only a *very* few!) of the diagrams and scans in the material may appear distorted
 on-screen. All should still be well on printouts, however.
 </div>


### PR DESCRIPTION
## Summary
- Adds `role="note"` and descriptive `aria-label` attributes to all custom callout `<div>` elements across the book (`.thought`, `.thought_commentary`, `.technical_aid`, `.workbook_callout`, `.neave_note`)
- 109 instances updated across 28 files (Days 1–5, index, and chapter template)
- Also normalises previously unquoted `class=foo` attributes to `class="foo"` for consistency

Closes #36

## Details

Each class gets a descriptive `aria-label` so screen readers announce meaningful context:

| Class | `aria-label` |
|---|---|
| `.thought` | "Thought" |
| `.thought_commentary` | "Commentary" |
| `.technical_aid` | "Technical aid" |
| `.workbook_callout` | "Workbook reference" |
| `.neave_note` | "Author's note" |

Uses `role="note"` (non-landmark) rather than `role="complementary"` to avoid polluting landmark navigation on pages with many callouts.

## Test plan
- [x] `quarto render` succeeds with no errors
- [x] Verified 108 `role="note"` attributes appear in rendered HTML across 27 output files
- [x] Verified zero remaining untagged callout divs in source `.qmd` files
- [ ] Screen reader testing: Tab through a content-heavy page (e.g. Day 3 Chapter 5) and verify callouts are announced with their labels


🤖 Generated with [Claude Code](https://claude.com/claude-code)