### PR TITLE
Consolidate duplicate CSS media query blocks

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -317,6 +317,28 @@ Usage:
   p {
     margin-bottom: 15px;
   }
+
+  /* Funnel experiment mobile overrides */
+  .fe-data-table {
+    font-size: 12px;
+  }
+  .fe-data-table td:first-child,
+  .fe-data-table th:first-child {
+    min-width: 100px;
+  }
+  .fe-button {
+    display: block;
+    width: 100%;
+    margin: 6px 0;
+    padding: 14px;
+    font-size: 16px;
+  }
+  .fe-comparison-grid {
+    grid-template-columns: 1fr;
+  }
+  .fe-status {
+    font-size: 13px;
+  }
 }
 
 /* Tablet styles (769px - 1024px) */
@@ -551,26 +573,3 @@ button:focus,
   font-weight: bold;
 }
 
-/* Mobile overrides */
-@media (max-width: 768px) {
-  .fe-data-table {
-    font-size: 12px;
-  }
-  .fe-data-table td:first-child,
-  .fe-data-table th:first-child {
-    min-width: 100px;
-  }
-  .fe-button {
-    display: block;
-    width: 100%;
-    margin: 6px 0;
-    padding: 14px;
-    font-size: 16px;
-  }
-  .fe-comparison-grid {
-    grid-template-columns: 1fr;
-  }
-  .fe-status {
-    font-size: 13px;
-  }
-}


### PR DESCRIPTION
## Summary
- Moved funnel experiment mobile overrides (formerly lines 550–571) into the main `@media (max-width: 768px)` block (after line 320)
- Removed the duplicate `@media (max-width: 768px)` wrapper so there is now only one mobile breakpoint block in `main.css`
- No functional CSS changes — identical rules, just reorganised

Closes #50

## Test plan
- [ ] Verify `quarto render` builds without errors
- [ ] Confirm only one `@media (max-width: 768px)` block exists in `main.css`
- [ ] Check funnel experiment pages at mobile viewport widths render correctly (buttons full-width, grid single-column, smaller table font)

🤖 Generated with [Claude Code](https://claude.com/claude-code)