### PR TITLE
Reduce download button boilerplate with createDownloadButton helper

### DIFF
--- a/assets/scripts/functions.js
+++ b/assets/scripts/functions.js
@@ -1,3 +1,12 @@
+export function createDownloadButton(inputs, fileName) {
+  const button = document.createElement("button");
+  button.className = "btn btn-primary";
+  button.type = "button";
+  button.textContent = "Download Your Notes";
+  button.onclick = () => downloadNotes(inputs, fileName);
+  return button;
+}
+
 export function downloadNotes(inputs, fileName) {
   const combinedText = combineInputValues(inputs);
   const blob = createTextBlob(combinedText);

--- a/content/days/day-01/07-quality-theory.qmd
+++ b/content/days/day-01/07-quality-theory.qmd
@@ -190,17 +190,7 @@ create_clock(11, 35)
 ::::
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof thought_1a, viewof thought_1b, viewof thought_1c], "thoughts_1a_1b_1c.txt");
-};
+createDownloadButton([viewof thought_1a, viewof thought_1b, viewof thought_1c], "thoughts_1a_1b_1c.txt")
 ```

--- a/content/days/day-01/08-attraction.qmd
+++ b/content/days/day-01/08-attraction.qmd
@@ -173,19 +173,9 @@ The other half are above average already, so why aren’t the rest? Think about 
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof activity_1d, viewof activity_1e_1, viewof activity_1e_2], "activities_1d_1e1_1e2.txt");
-};
+createDownloadButton([viewof activity_1d, viewof activity_1e_1, viewof activity_1e_2], "activities_1d_1e1_1e2.txt")
 ```
 
 <!--

--- a/content/days/day-01/13-major-activity.qmd
+++ b/content/days/day-01/13-major-activity.qmd
@@ -204,17 +204,7 @@ viewof activity_1f_10b = Inputs.textarea({
 
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof activity_1f_1a, viewof activity_1f_1b, viewof activity_1f_2a, viewof activity_1f_2b, viewof activity_1f_3a, viewof activity_1f_3b, viewof activity_1f_4a, viewof activity_1f_4b, viewof activity_1f_5a, viewof activity_1f_5b, viewof activity_1f_6a, viewof activity_1f_6b, viewof activity_1f_7a, viewof activity_1f_7b, viewof activity_1f_8a, viewof activity_1f_8b, viewof activity_1f_9a, viewof activity_1f_9b, viewof activity_1f_10a, viewof activity_1f_10b], "major_activity_1f.txt");
-};
+createDownloadButton([viewof activity_1f_1a, viewof activity_1f_1b, viewof activity_1f_2a, viewof activity_1f_2b, viewof activity_1f_3a, viewof activity_1f_3b, viewof activity_1f_4a, viewof activity_1f_4b, viewof activity_1f_5a, viewof activity_1f_5b, viewof activity_1f_6a, viewof activity_1f_6b, viewof activity_1f_7a, viewof activity_1f_7b, viewof activity_1f_8a, viewof activity_1f_8b, viewof activity_1f_9a, viewof activity_1f_9b, viewof activity_1f_10a, viewof activity_1f_10b], "major_activity_1f.txt")
 ```

--- a/content/days/day-02/01-run-charts.qmd
+++ b/content/days/day-02/01-run-charts.qmd
@@ -159,17 +159,7 @@ All I can say is that, in my experience, the answer is **Yes!** I might comment 
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof thought_2a], "thought_2a.txt");
-};
+createDownloadButton([viewof thought_2a], "thought_2a.txt")
 ```

--- a/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
+++ b/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
@@ -97,5 +97,5 @@ viewof thought_2c_ii = Inputs.textarea({label: "Should we be wary of illusions o
 ```{ojs download_all}
 import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-createDownloadButton([viewof thought_2b_i, thought_2b_ii, thought_2b_iii, thought_2b_iv, thought_2c_i, thought_2c_ii], "thought_2b_2c.txt")
+createDownloadButton([viewof thought_2b_i, viewof thought_2b_ii, viewof thought_2b_iii, viewof thought_2b_iv, viewof thought_2c_i, viewof thought_2c_ii], "thought_2b_2c.txt")
 ```

--- a/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
+++ b/content/days/day-02/02-intro-to-the-red-beads-experiment.qmd
@@ -95,17 +95,7 @@ viewof thought_2c_ii = Inputs.textarea({label: "Should we be wary of illusions o
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof thought_2b_i, thought_2b_ii, thought_2b_iii, thought_2b_iv, thought_2c_i, thought_2c_ii], "thought_2b_2c.txt");
-};
+createDownloadButton([viewof thought_2b_i, thought_2b_ii, thought_2b_iii, thought_2b_iv, thought_2c_i, thought_2c_ii], "thought_2b_2c.txt")
 ```

--- a/content/days/day-02/03-a-brief-overview.qmd
+++ b/content/days/day-02/03-a-brief-overview.qmd
@@ -90,17 +90,7 @@ At this stage, the experiment was abruptly terminated. Despite everybody's hard 
 And so the experiment came to an abrupt and unhappy end.
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof thought_2d], "thought_2d.txt");
-};
+createDownloadButton([viewof thought_2d], "thought_2d.txt")
 ```

--- a/content/days/day-02/04-our-first-control-chart.qmd
+++ b/content/days/day-02/04-our-first-control-chart.qmd
@@ -69,17 +69,7 @@ viewof thought_2e = Inputs.textarea({label: "What does the control chart tell yo
 Are you startled by what the control chart has just told you? Fear not: all will be revealed!
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof thought_2e], "thought_2e.txt");
-};
+createDownloadButton([viewof thought_2e], "thought_2e.txt")
 ```

--- a/content/days/day-03/01-variation-the-enemy-of-quality.qmd
+++ b/content/days/day-03/01-variation-the-enemy-of-quality.qmd
@@ -92,16 +92,7 @@ viewof activity_3b_2 = Inputs.textarea({label: "How might reducing variation lea
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof activity_3a_1, viewof activity_3a_2, viewof activity_3b_1, viewof activity_3b_2], "activities_3a_3b.txt");
-};
+createDownloadButton([viewof activity_3a_1, viewof activity_3a_2, viewof activity_3b_1, viewof activity_3b_2], "activities_3a_3b.txt")
 ```

--- a/content/days/day-03/02-at-the-ford-motor-company.qmd
+++ b/content/days/day-03/02-at-the-ford-motor-company.qmd
@@ -37,16 +37,7 @@ viewof activity_3c = Inputs.textarea({label: "How could turning off the compensa
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof activity_3c], "activity_3c.txt");
-};
+createDownloadButton([viewof activity_3c], "activity_3c.txt")
 ```

--- a/content/days/day-03/03-the-importance-of-time.qmd
+++ b/content/days/day-03/03-the-importance-of-time.qmd
@@ -88,16 +88,7 @@ Observing the rather abrupt cut-off on the left hand side at 6.2 mils (millimetr
 Actually, if you look carefully at the first of the two Ford histograms on page 5, I think you will find that it contains not 50 but just 49 "boxes". Maybe there was one that fell just outside specifications and, well, ... vanished.
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof activity_3d, viewof activity_3e], "activities_3d_3e.txt");
-};
+createDownloadButton([viewof activity_3d, viewof activity_3e], "activities_3d_3e.txt")
 ```

--- a/content/days/day-03/04-more-on-the-sales-data.qmd
+++ b/content/days/day-03/04-more-on-the-sales-data.qmd
@@ -93,16 +93,7 @@ Incidentally, you may have noticed that every control chart you have seen so far
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof thought_3f], "thought_3f.txt");
-};
+createDownloadButton([viewof thought_3f], "thought_3f.txt")
 ```

--- a/content/days/day-03/05-how-do-we-compute-control-limits.qmd
+++ b/content/days/day-03/05-how-do-we-compute-control-limits.qmd
@@ -150,16 +150,7 @@ viewof activity_3g = Inputs.textarea({label: "Compute control limits and interpr
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([viewof activity_3g], "activity_3g.txt");
-};
+createDownloadButton([viewof activity_3g], "activity_3g.txt")
 ```

--- a/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
+++ b/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
@@ -250,15 +250,7 @@ So, to summarise, we have just seen that it is Rule 1 of the Funnel which has pr
 Let's now move on to ...
 
 ```{ojs download_ch11}
-download_button_ch11 = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger_ch11}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button_ch11.onclick = () => {
-  downloadNotes([], "funnel_rule1_rule2_notes.txt");
-};
+createDownloadButton([], "funnel_rule1_rule2_notes.txt")
 ```

--- a/content/days/day-03/13-summary.qmd
+++ b/content/days/day-03/13-summary.qmd
@@ -237,15 +237,7 @@ If you'd like to repeat the entire experiment with a fresh set of dice rolls, cl
 ```
 
 ```{ojs download_ch13}
-download_button_ch13 = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger_ch13}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button_ch13.onclick = () => {
-  downloadNotes([viewof activity_3i, viewof activity_3j], "activities_3i_3j.txt");
-};
+createDownloadButton([viewof activity_3i, viewof activity_3j], "activities_3i_3j.txt")
 ```

--- a/content/days/day-04/02-the-joiner-triangle.qmd
+++ b/content/days/day-04/02-the-joiner-triangle.qmd
@@ -279,23 +279,14 @@ So here for your convenience is the expanded Joiner Triangle again but now with 
 </div>
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([
-    viewof activity_4a_1, viewof activity_4a_2, viewof activity_4a_3,
-    viewof activity_4b_yes, viewof activity_4b_no,
-    viewof thought_4c,
-    viewof activity_4d_a1, viewof activity_4d_a2, viewof activity_4d_a3,
-    viewof activity_4d_b1, viewof activity_4d_b2, viewof activity_4d_b3,
-    viewof activity_4d_c1, viewof activity_4d_c2, viewof activity_4d_c3
-  ], "activities_4a_4b_4c_4d.txt");
-};
+createDownloadButton([
+  viewof activity_4a_1, viewof activity_4a_2, viewof activity_4a_3,
+  viewof activity_4b_yes, viewof activity_4b_no,
+  viewof thought_4c,
+  viewof activity_4d_a1, viewof activity_4d_a2, viewof activity_4d_a3,
+  viewof activity_4d_b1, viewof activity_4d_b2, viewof activity_4d_b3,
+  viewof activity_4d_c1, viewof activity_4d_c2, viewof activity_4d_c3
+], "activities_4a_4b_4c_4d.txt")
 ```

--- a/content/days/day-04/04-points-1-to-6.qmd
+++ b/content/days/day-04/04-points-1-to-6.qmd
@@ -300,23 +300,14 @@ viewof p6_sa = Inputs.textarea({
 As you know, this project will continue throughout Day 5. So get ready to keep up the good work tomorrow!
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([
-    viewof p1_owq, viewof p1_aot, viewof p1_sa,
-    viewof p2_owq, viewof p2_aot, viewof p2_sa,
-    viewof p3_owq, viewof p3_aot, viewof p3_sa,
-    viewof p4_owq, viewof p4_aot, viewof p4_sa,
-    viewof p5_owq, viewof p5_aot, viewof p5_sa,
-    viewof p6_owq, viewof p6_aot, viewof p6_sa
-  ], "points_1_to_6.txt");
-};
+createDownloadButton([
+  viewof p1_owq, viewof p1_aot, viewof p1_sa,
+  viewof p2_owq, viewof p2_aot, viewof p2_sa,
+  viewof p3_owq, viewof p3_aot, viewof p3_sa,
+  viewof p4_owq, viewof p4_aot, viewof p4_sa,
+  viewof p5_owq, viewof p5_aot, viewof p5_sa,
+  viewof p6_owq, viewof p6_aot, viewof p6_sa
+], "points_1_to_6.txt")
 ```

--- a/content/days/day-05/02-points-7-to-14.qmd
+++ b/content/days/day-05/02-points-7-to-14.qmd
@@ -516,25 +516,16 @@ create_clock(12, 0)
 ---
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([
-    viewof p7_owq, viewof p7_aot, viewof p7_sa,
-    viewof p8_owq, viewof p8_aot, viewof p8_sa,
-    viewof p9_owq, viewof p9_aot, viewof p9_sa,
-    viewof p10_owq, viewof p10_aot, viewof p10_sa,
-    viewof p11_owq, viewof p11_aot, viewof p11_sa,
-    viewof p12_owq, viewof p12_aot, viewof p12_sa,
-    viewof p13_owq, viewof p13_aot, viewof p13_sa,
-    viewof p14_owq, viewof p14_aot, viewof p14_sa
-  ], "points_7_to_14.txt");
-};
+createDownloadButton([
+  viewof p7_owq, viewof p7_aot, viewof p7_sa,
+  viewof p8_owq, viewof p8_aot, viewof p8_sa,
+  viewof p9_owq, viewof p9_aot, viewof p9_sa,
+  viewof p10_owq, viewof p10_aot, viewof p10_sa,
+  viewof p11_owq, viewof p11_aot, viewof p11_sa,
+  viewof p12_owq, viewof p12_aot, viewof p12_sa,
+  viewof p13_owq, viewof p13_aot, viewof p13_sa,
+  viewof p14_owq, viewof p14_aot, viewof p14_sa
+], "points_7_to_14.txt")
 ```

--- a/content/days/day-05/03-the-deadly-diseases.qmd
+++ b/content/days/day-05/03-the-deadly-diseases.qmd
@@ -332,24 +332,15 @@ That's it! Congratulations on completing this major project. You may now relax a
 ---
 
 ```{ojs download_all}
-// Download button element
-download_button = html`<button class="btn btn-primary" type="button">Download Your Notes</button>`
-```
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
 
-```{ojs download_trigger}
-//| output: false
-
-import { downloadNotes } from "../../../assets/scripts/functions.js"
-
-download_button.onclick = () => {
-  downloadNotes([
-    viewof d1_owq, viewof d1_aot, viewof d1_sa,
-    viewof d2_owq, viewof d2_aot, viewof d2_sa,
-    viewof d3_owq, viewof d3_aot, viewof d3_sa,
-    viewof d4_owq, viewof d4_aot, viewof d4_sa,
-    viewof d5_owq, viewof d5_aot, viewof d5_sa
-  ], "deadly_diseases.txt");
-};
+createDownloadButton([
+  viewof d1_owq, viewof d1_aot, viewof d1_sa,
+  viewof d2_owq, viewof d2_aot, viewof d2_sa,
+  viewof d3_owq, viewof d3_aot, viewof d3_sa,
+  viewof d4_owq, viewof d4_aot, viewof d4_sa,
+  viewof d5_owq, viewof d5_aot, viewof d5_sa
+], "deadly_diseases.txt")
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Added `createDownloadButton(inputs, fileName)` to `functions.js` that creates the button element, wires the onclick handler, and returns it for OJS to render
- Replaced the two-block pattern (button creation + download trigger) with a single OJS block across all 18 chapter files
- Net change: +78 lines, -236 lines (158 lines removed)

Closes #52

## Test plan
- [ ] Run `quarto render` — build succeeds with no errors (verified locally)
- [ ] Open a chapter with a download button (e.g. Day 1 Quality Theory) and verify the button renders
- [ ] Fill in activity textareas and click "Download Your Notes" — verify the .txt file downloads with correct content
- [ ] Spot-check chapters across days 1-5 to confirm all download buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)