### PR TITLE
Manage igraph through renv instead of CI workaround

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,16 +64,6 @@ jobs:
     - name: Ensure renv library directory exists
       run: mkdir -p renv/library
 
-    - name: Pre-install igraph in renv library
-      run: |
-        R_LIBPATH="renv/library/R-$(RENV_PROJECT="" Rscript --vanilla -e 'cat(paste(R.version$major, strsplit(R.version$minor, ".", fixed=TRUE)[[1]][1], sep="."))')/x86_64-pc-linux-gnu"
-        mkdir -p "$R_LIBPATH"
-        Rscript -e "install.packages('igraph', lib = '$R_LIBPATH')"
-
-    - name: Test igraph install
-      run: |
-        Rscript -e 'library(igraph); sessionInfo()'
-
     - name: Cache R packages
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:

--- a/renv.lock
+++ b/renv.lock
@@ -482,6 +482,29 @@
       ],
       "Hash": "04291cc45198225444a397606810ac37"
     },
+    "igraph": {
+      "Package": "igraph",
+      "Version": "2.2.2",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "Matrix",
+        "cli",
+        "cpp11",
+        "grDevices",
+        "graphics",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pkgconfig",
+        "rlang",
+        "stats",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "f5c501f18510803806e60517cdd84cc4"
+    },
     "isoband": {
       "Package": "isoband",
       "Version": "0.3.0",

--- a/renv/settings.json
+++ b/renv/settings.json
@@ -1,7 +1,7 @@
 {
   "bioconductor.version": null,
   "external.libraries": [],
-  "ignored.packages": ["digest", "igraph"],
+  "ignored.packages": ["digest"],
   "package.dependency.fields": [
     "Imports",
     "Depends",


### PR DESCRIPTION
## Summary

Closes #55.

- **Removed** the `Pre-install igraph in renv library` and `Test igraph install` steps from `deploy.yml` — these were a fragile workaround that installed an unlocked version of igraph outside renv's control
- **Added** igraph 2.2.2 to `renv.lock` with its full dependency list and hash, so `renv::restore()` installs it like any other package
- **Removed** igraph from `ignored.packages` in `renv/settings.json` so renv manages it normally

The required system dependencies (`libglpk-dev`, `libgmp3-dev`, `libxml2-dev`) are already present in the `apt-get install` step, so igraph compiles without the workaround.

## Test plan

- [ ] CI build passes — `renv::restore()` installs igraph without the pre-install step
- [ ] R unit tests pass (igraph is a dependency of DiagrammeR)
- [ ] Quarto book builds and smoke test passes
- [ ] Deployed site functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)