### PR TITLE
Add structural inventory checker for QMD chapter completeness

### DIFF
--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -10,6 +10,8 @@
 # headings, download button, workbook callout.
 #
 # Requires: ruby (for YAML parsing — ships with macOS)
+# Note: CI (Ubuntu) does not install Ruby by default. If wiring into CI,
+# add ruby to the workflow's setup steps.
 
 set -euo pipefail
 
@@ -51,7 +53,12 @@ expand_manifest() {
   local manifest="$1"
   local outdir="$2"
   ruby -ryaml -e '
-    data = YAML.safe_load(File.read(ARGV[0]))
+    begin
+      data = YAML.safe_load(File.read(ARGV[0]))
+    rescue => e
+      $stderr.puts "Error parsing manifest #{ARGV[0]}: #{e.message}"
+      exit 1
+    end
     outdir = ARGV[1]
     data["chapters"].each_with_index do |ch, i|
       File.open("#{outdir}/ch_#{format("%02d", i)}", "w") do |f|
@@ -138,6 +145,7 @@ main() {
   local total_checks=0
   local total_pass=0
   local total_fail=0
+  local total_warn=0
 
   for ch_file in "$tmpdir"/ch_*; do
     # Read chapter metadata
@@ -271,6 +279,7 @@ main() {
       else
         warn "headings: $actual_hdg_count found but none in manifest"
         total_pass=$((total_pass + 1))
+        total_warn=$((total_warn + 1))
       fi
     fi
 
@@ -288,6 +297,7 @@ main() {
       if grep -q 'createDownloadButton' "$qmd_path" 2>/dev/null; then
         warn "download button: found but not in manifest"
         total_pass=$((total_pass + 1))
+        total_warn=$((total_warn + 1))
       else
         pass "download button: none expected"
         total_pass=$((total_pass + 1))
@@ -308,6 +318,7 @@ main() {
       if grep -q 'workbook_callout' "$qmd_path" 2>/dev/null; then
         warn "workbook callout: found but not in manifest"
         total_pass=$((total_pass + 1))
+        total_warn=$((total_warn + 1))
       else
         pass "workbook callout: none expected"
         total_pass=$((total_pass + 1))
@@ -328,6 +339,9 @@ main() {
     printf "  Failed:         ${RED}%d${RESET}\n" "$total_fail"
   else
     echo "  Failed:         0"
+  fi
+  if (( total_warn > 0 )); then
+    printf "  Warnings:       ${YELLOW}%d${RESET}  (elements found but not in manifest)\n" "$total_warn"
   fi
   echo ""
 

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+#
+# check-structure.sh — Structural inventory checker for QMD chapter completeness
+#
+# Usage: ./scripts/check-structure.sh <day-number>
+#   e.g. ./scripts/check-structure.sh 3
+#
+# Compares each QMD chapter against a per-day manifest and reports PASS/FAIL
+# per check per chapter. Checks: viewof count, figure existence, section
+# headings, download button, workbook callout.
+#
+# Requires: ruby (for YAML parsing — ships with macOS)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONTENT_DIR="$REPO_ROOT/content/days"
+MANIFEST_DIR="$REPO_ROOT/workflow/validation"
+TMPDIR_CLEANUP=""
+
+# ── Colours ───────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  YELLOW='\033[0;33m'
+  BOLD='\033[1m'
+  RESET='\033[0m'
+else
+  GREEN='' RED='' YELLOW='' BOLD='' RESET=''
+fi
+
+# ── Helpers ───────────────────────────────────────────────────
+
+usage() {
+  echo "Usage: $0 <day-number>"
+  echo "  day-number: 1-12"
+  echo ""
+  echo "Checks QMD chapters against a structural manifest and reports"
+  echo "PASS/FAIL per check per chapter."
+  exit 1
+}
+
+pass() { printf "  ${GREEN}PASS${RESET} %s\n" "$1"; }
+fail() { printf "  ${RED}FAIL${RESET} %s\n" "$1"; }
+warn() { printf "  ${YELLOW}WARN${RESET} %s\n" "$1"; }
+
+# Expand manifest into a flat text format using Ruby, one file per chapter.
+# Each chapter file contains key=value lines, with multi-value fields
+# (figures, headings) on separate ITEM= lines.
+expand_manifest() {
+  local manifest="$1"
+  local outdir="$2"
+  ruby -ryaml -e '
+    data = YAML.safe_load(File.read(ARGV[0]))
+    outdir = ARGV[1]
+    data["chapters"].each_with_index do |ch, i|
+      File.open("#{outdir}/ch_#{format("%02d", i)}", "w") do |f|
+        f.puts "FILE=#{ch["file"]}"
+        f.puts "VIEWOF=#{ch["viewof_count"]}"
+        f.puts "DOWNLOAD=#{ch["has_download_button"]}"
+        f.puts "WORKBOOK=#{ch["has_workbook_callout"]}"
+        (ch["figures"] || []).each { |fig| f.puts "FIGURE=#{fig}" }
+        (ch["headings"] || []).each { |h| f.puts "HEADING=#{h}" }
+      end
+    end
+  ' "$manifest" "$outdir"
+}
+
+# Count viewof declarations (viewof name =) in a QMD file
+count_viewof() {
+  local n
+  n=$(grep -cE 'viewof [a-zA-Z_][a-zA-Z0-9_]* =' "$1" 2>/dev/null) || true
+  echo "${n:-0}"
+}
+
+# Extract ## headings from a QMD file, stripping Quarto attributes and HTML tags
+extract_headings() {
+  grep '^## ' "$1" 2>/dev/null | sed -E '
+    s/^## //
+    s/ *\{[^}]*\}$//
+    s/<[^>]+>//g
+    s/^ +//
+    s/ +$//
+    s/  +/ /g
+  ' || true
+}
+
+# ── Main ──────────────────────────────────────────────────────
+
+main() {
+  local day_num="${1:-}"
+
+  if [[ -z "$day_num" || ! "$day_num" =~ ^[0-9]+$ ]]; then
+    usage
+  fi
+
+  if (( day_num < 1 || day_num > 12 )); then
+    echo "Error: day-number must be between 1 and 12"
+    exit 1
+  fi
+
+  if ! command -v ruby &>/dev/null; then
+    echo "Error: ruby not found (needed for YAML parsing)"
+    exit 1
+  fi
+
+  local day_dir
+  day_dir=$(printf "day-%02d" "$day_num")
+  local manifest="$MANIFEST_DIR/${day_dir}-manifest.yml"
+  local qmd_dir="$CONTENT_DIR/$day_dir"
+
+  if [[ ! -f "$manifest" ]]; then
+    echo "Error: No manifest found at $manifest"
+    echo "Create one before running this check."
+    exit 1
+  fi
+
+  if [[ ! -d "$qmd_dir" ]]; then
+    echo "Error: No content directory at $qmd_dir"
+    exit 1
+  fi
+
+  echo "=========================================="
+  echo "  Structural Inventory Report"
+  echo "  Day $day_num"
+  echo "=========================================="
+  echo ""
+  echo "Manifest: $(basename "$manifest")"
+  echo "QMD dir:  $day_dir/"
+  echo ""
+
+  # Expand manifest into per-chapter temp files
+  TMPDIR_CLEANUP=$(mktemp -d)
+  local tmpdir="$TMPDIR_CLEANUP"
+  trap 'rm -rf "$TMPDIR_CLEANUP"' EXIT
+  expand_manifest "$manifest" "$tmpdir"
+
+  local total_checks=0
+  local total_pass=0
+  local total_fail=0
+
+  for ch_file in "$tmpdir"/ch_*; do
+    # Read chapter metadata
+    local file="" expected_viewof=0 expected_dl="false" expected_wc="false"
+    local figures="" headings=""
+
+    while IFS='=' read -r key value; do
+      case "$key" in
+        FILE)     file="$value" ;;
+        VIEWOF)   expected_viewof="$value" ;;
+        DOWNLOAD) expected_dl="$value" ;;
+        WORKBOOK) expected_wc="$value" ;;
+        FIGURE)
+          if [[ -n "$figures" ]]; then
+            figures="$figures"$'\n'"$value"
+          else
+            figures="$value"
+          fi
+          ;;
+        HEADING)
+          if [[ -n "$headings" ]]; then
+            headings="$headings"$'\n'"$value"
+          else
+            headings="$value"
+          fi
+          ;;
+      esac
+    done < "$ch_file"
+
+    local qmd_path="$qmd_dir/$file"
+    printf "${BOLD}%s${RESET}\n" "$file"
+
+    # Check file exists
+    if [[ ! -f "$qmd_path" ]]; then
+      fail "File not found: $qmd_path"
+      total_checks=$((total_checks + 1))
+      total_fail=$((total_fail + 1))
+      echo ""
+      continue
+    fi
+
+    # ── Check 1: viewof count ──
+    local actual_viewof
+    actual_viewof=$(count_viewof "$qmd_path")
+    total_checks=$((total_checks + 1))
+    if [[ "$actual_viewof" -eq "$expected_viewof" ]]; then
+      pass "viewof declarations: $actual_viewof (expected $expected_viewof)"
+      total_pass=$((total_pass + 1))
+    else
+      fail "viewof declarations: $actual_viewof (expected $expected_viewof)"
+      total_fail=$((total_fail + 1))
+    fi
+
+    # ── Check 2: figure references ──
+    # Check manifest figures exist on disk
+    if [[ -n "$figures" ]]; then
+      while IFS= read -r fig_path; do
+        [[ -z "$fig_path" ]] && continue
+        total_checks=$((total_checks + 1))
+        local full_path="$REPO_ROOT$fig_path"
+        if [[ -f "$full_path" ]]; then
+          pass "figure exists: $(basename "$fig_path")"
+          total_pass=$((total_pass + 1))
+        else
+          fail "figure missing: $fig_path"
+          total_fail=$((total_fail + 1))
+        fi
+      done <<< "$figures"
+    else
+      total_checks=$((total_checks + 1))
+      pass "figures: none expected"
+      total_pass=$((total_pass + 1))
+    fi
+
+    # Check all ![...](path) refs in QMD point to existing files
+    # Use Ruby for reliable parsing — regex alone can't handle parentheses in alt text
+    local qmd_figs
+    qmd_figs=$(ruby -e '
+      ARGF.each_line do |line|
+        line.scan(/!\[[^\]]*\]\(([^)]+)\)/) { |m| puts m[0] }
+      end
+    ' "$qmd_path" 2>/dev/null | sed 's/%20/ /g' || true)
+    if [[ -n "$qmd_figs" ]]; then
+      while IFS= read -r ref_path; do
+        [[ -z "$ref_path" ]] && continue
+        [[ "$ref_path" == http* ]] && continue
+        total_checks=$((total_checks + 1))
+        local full_ref="$REPO_ROOT$ref_path"
+        if [[ -f "$full_ref" ]]; then
+          pass "image ref OK: $(basename "$ref_path")"
+          total_pass=$((total_pass + 1))
+        else
+          fail "image ref broken: $ref_path"
+          total_fail=$((total_fail + 1))
+        fi
+      done <<< "$qmd_figs"
+    fi
+
+    # ── Check 3: section headings ──
+    if [[ -n "$headings" ]]; then
+      local actual_hdgs
+      actual_hdgs=$(extract_headings "$qmd_path")
+
+      # Build temporary files for comparison (normalise smart quotes to ASCII)
+      local exp_file="$tmpdir/exp_hdg"
+      local act_file="$tmpdir/act_hdg"
+      echo "$headings" | sed -E 's/^ +//; s/ +$//; s/  +/ /g' \
+        | ruby -e 'STDIN.each_line{|l| puts l.gsub(/[\u2018\u2019]/,"'\''").gsub(/[\u201C\u201D]/,"\"") }' > "$exp_file"
+      echo "$actual_hdgs" | sed -E 's/^ +//; s/ +$//; s/  +/ /g' \
+        | ruby -e 'STDIN.each_line{|l| puts l.gsub(/[\u2018\u2019]/,"'\''").gsub(/[\u201C\u201D]/,"\"") }' > "$act_file"
+
+      total_checks=$((total_checks + 1))
+      if diff -q "$exp_file" "$act_file" >/dev/null 2>&1; then
+        local hdg_count
+        hdg_count=$(wc -l < "$exp_file" | tr -d ' ')
+        pass "headings: $hdg_count match"
+        total_pass=$((total_pass + 1))
+      else
+        fail "headings: mismatch"
+        total_fail=$((total_fail + 1))
+        diff --label expected --label actual "$exp_file" "$act_file" | head -10 | sed 's/^/       /'
+      fi
+    else
+      total_checks=$((total_checks + 1))
+      local actual_hdg_count
+      actual_hdg_count=$(grep -c '^## ' "$qmd_path" 2>/dev/null) || true
+      actual_hdg_count="${actual_hdg_count:-0}"
+      if [[ "$actual_hdg_count" -eq 0 ]]; then
+        pass "headings: none expected, none found"
+        total_pass=$((total_pass + 1))
+      else
+        warn "headings: $actual_hdg_count found but none in manifest"
+        total_pass=$((total_pass + 1))
+      fi
+    fi
+
+    # ── Check 4: download button ──
+    total_checks=$((total_checks + 1))
+    if [[ "$expected_dl" == "true" ]]; then
+      if grep -q 'createDownloadButton' "$qmd_path" 2>/dev/null; then
+        pass "download button: present"
+        total_pass=$((total_pass + 1))
+      else
+        fail "download button: missing (expected)"
+        total_fail=$((total_fail + 1))
+      fi
+    else
+      if grep -q 'createDownloadButton' "$qmd_path" 2>/dev/null; then
+        warn "download button: found but not in manifest"
+        total_pass=$((total_pass + 1))
+      else
+        pass "download button: none expected"
+        total_pass=$((total_pass + 1))
+      fi
+    fi
+
+    # ── Check 5: workbook callout ──
+    total_checks=$((total_checks + 1))
+    if [[ "$expected_wc" == "true" ]]; then
+      if grep -q 'workbook_callout' "$qmd_path" 2>/dev/null; then
+        pass "workbook callout: present"
+        total_pass=$((total_pass + 1))
+      else
+        fail "workbook callout: missing (expected)"
+        total_fail=$((total_fail + 1))
+      fi
+    else
+      if grep -q 'workbook_callout' "$qmd_path" 2>/dev/null; then
+        warn "workbook callout: found but not in manifest"
+        total_pass=$((total_pass + 1))
+      else
+        pass "workbook callout: none expected"
+        total_pass=$((total_pass + 1))
+      fi
+    fi
+
+    echo ""
+  done
+
+  # ── Summary ──
+  echo "=========================================="
+  echo "  Summary"
+  echo "=========================================="
+  echo ""
+  echo "  Total checks:  $total_checks"
+  printf "  Passed:         ${GREEN}%d${RESET}\n" "$total_pass"
+  if (( total_fail > 0 )); then
+    printf "  Failed:         ${RED}%d${RESET}\n" "$total_fail"
+  else
+    echo "  Failed:         0"
+  fi
+  echo ""
+
+  if (( total_fail == 0 )); then
+    printf "${GREEN}All structural checks passed.${RESET}\n"
+  else
+    printf "${RED}%d check(s) failed — review above for details.${RESET}\n" "$total_fail"
+  fi
+  echo ""
+
+  # Exit with failure count (capped at 125 for valid exit codes)
+  if (( total_fail > 125 )); then
+    return 125
+  fi
+  return "$total_fail"
+}
+
+main "$@"

--- a/workflow/validation/day-01-manifest.yml
+++ b/workflow/validation/day-01-manifest.yml
@@ -1,0 +1,130 @@
+# Day 1 structural manifest
+# Generated from completed QMD files — baseline for regression checks
+day: 1
+
+chapters:
+  - file: "01-overture.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-01/day_1_fig_1.jpg"
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "02-rediscovered.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-01/day_1_fig_2.png"
+      - "/assets/images/day-01/day_1_fig_3.jpg"
+      - "/assets/images/day-01/day_1_fig_4.png"
+      - "/assets/images/day-01/day_1_fig_5.png"
+    headings:
+      - "The Deming Prize and the Nashua Corporation"
+      - "The four-day seminars"
+      - "The British Deming Association and later"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "03-statistics.qmd"
+    viewof_count: 0
+    figures: []
+    headings:
+      - "Statistics?"
+      - "The two paradoxes"
+      - "Control charts in this course"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "04-resources.qmd"
+    viewof_count: 0
+    figures: []
+    headings:
+      - "The Deming Dimension"
+      - "Other books"
+      - "Videos"
+      - "And finally..."
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "05-activities.qmd"
+    viewof_count: 0
+    figures: []
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "06-outline.qmd"
+    viewof_count: 0
+    figures: []
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "07-quality-theory.qmd"
+    viewof_count: 3
+    figures: []
+    headings:
+      - "PAUSE FOR THOUGHT 1-a"
+      - "PAUSE FOR THOUGHT 1-b"
+      - "PAUSE FOR THOUGHT 1–c"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "08-attraction.qmd"
+    viewof_count: 3
+    figures: []
+    headings:
+      - "ACTIVITY 1-d"
+      - "PAUSE FOR THOUGHT 1–e"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "09-different.qmd"
+    viewof_count: 0
+    figures: []
+    headings:
+      - "How different?"
+      - "So what kind of environment is this Deming \"optimum\" system?"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "10-relief.qmd"
+    viewof_count: 0
+    figures: []
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "11-deming-story.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-01/day_1_fig_6.png"
+      - "/assets/images/day-01/day_1_fig_7.png"
+    headings:
+      - "Early 1900s: The story begins"
+      - "The 1920s: New statistics in manufacturing"
+      - "Shewhart's breakthrough"
+      - "1930s–1940s: New statistics in non-manufacturing"
+      - "1950s–1960s: \"The theory of a system, and cooperation\""
+      - "A Summary of Teachings to Top Management and to Engineers in Japan"
+      - "The 1970s: The wasted years"
+      - "The 1980s (first half): The West awakens"
+      - "The 1980s (second half): A new climate"
+      - "1990–1993: A System of Profound Knowledge"
+      - "1994 and onward: The future"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "12-intro-activity.qmd"
+    viewof_count: 0
+    figures: []
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "13-major-activity.qmd"
+    viewof_count: 20
+    figures: []
+    headings: []
+    has_download_button: true
+    has_workbook_callout: true

--- a/workflow/validation/day-02-manifest.yml
+++ b/workflow/validation/day-02-manifest.yml
@@ -1,0 +1,92 @@
+# Day 2 structural manifest
+# Generated from completed QMD files — baseline for regression checks
+day: 2
+
+chapters:
+  - file: "01-run-charts.qmd"
+    viewof_count: 1
+    figures:
+      - "/assets/images/day-02/Picture 1.jpg"
+    headings:
+      - "PAUSE FOR THOUGHT 2–a"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "02-intro-to-the-red-beads-experiment.qmd"
+    viewof_count: 6
+    figures: []
+    headings:
+      - "PAUSE FOR THOUGHT 2–b"
+      - "PAUSE FOR THOUGHT 2–c"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "03-a-brief-overview.qmd"
+    viewof_count: 1
+    figures:
+      - "/assets/images/day-02/image-2.png"
+    headings:
+      - "PAUSE FOR THOUGHT 2–d"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "04-our-first-control-chart.qmd"
+    viewof_count: 1
+    figures: []
+    headings:
+      - "PAUSE FOR THOUGHT 2–e"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "05-the-truth-the-whole-truth-and-nothing-but.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-02/image-4.jpg"
+    headings:
+      - "The training, part 1"
+      - "The training, part 2"
+      - "The \"real work\""
+      - "The Technical Aids"
+    has_download_button: false
+    has_workbook_callout: true
+
+  - file: "06-your-turn.qmd"
+    viewof_count: 20
+    figures: []
+    headings:
+      - "ACTIVITY 2–f"
+    has_download_button: false
+    has_workbook_callout: true
+
+  - file: "07-some-recollections.qmd"
+    viewof_count: 12
+    figures:
+      - "/assets/images/day-02/image-5.jpg"
+      - "/assets/images/day-02/image-6.png"
+      - "/assets/images/day-02/image-7.png"
+      - "/assets/images/day-02/image-8.png"
+      - "/assets/images/day-02/image-9.png"
+      - "/assets/images/day-02/image-10.png"
+      - "/assets/images/day-02/image-11.png"
+      - "/assets/images/day-02/image-12.png"
+      - "/assets/images/day-02/image-13.png"
+      - "/assets/images/day-02/image-14.png"
+    headings:
+      - "PAUSE FOR THOUGHT 2–e"
+    has_download_button: false
+    has_workbook_callout: true
+
+  - file: "08-major-activity.qmd"
+    viewof_count: 2
+    figures: []
+    headings: []
+    has_download_button: false
+    has_workbook_callout: true
+
+  - file: "09-postscript.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-02/postscript-table.png"
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false

--- a/workflow/validation/day-03-manifest.yml
+++ b/workflow/validation/day-03-manifest.yml
@@ -1,0 +1,152 @@
+# Day 3 structural manifest
+# Generated from completed QMD files — baseline for regression checks
+day: 3
+
+chapters:
+  - file: "01-variation-the-enemy-of-quality.qmd"
+    viewof_count: 4
+    figures: []
+    headings:
+      - "Variation—the enemy of quality"
+      - "BACK TO THE WESTERN ELECTRIC COMPANY"
+      - "ACTIVITY 3–a"
+      - "ACTIVITY 3–b"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "02-at-the-ford-motor-company.qmd"
+    viewof_count: 1
+    figures:
+      - "/assets/images/day-03/ford-histogram-with-compensation.png"
+      - "/assets/images/day-03/ford-histogram-without-compensation.png"
+    headings:
+      - "ACTIVITY 3–c"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "03-the-importance-of-time.qmd"
+    viewof_count: 2
+    figures:
+      - "/assets/images/day-03/two-histograms-24-values.png"
+      - "/assets/images/day-03/run-chart-first-process.png"
+      - "/assets/images/day-03/deming-histogram-caliper.png"
+    headings:
+      - "ACTIVITY 3–d"
+      - "ACTIVITY 3–e"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "04-more-on-the-sales-data.qmd"
+    viewof_count: 1
+    figures:
+      - "/assets/images/day-03/sales-control-chart.png"
+    headings:
+      - "PAUSE FOR THOUGHT 3–f"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "05-how-do-we-compute-control-limits.qmd"
+    viewof_count: 1
+    figures:
+      - "/assets/images/day-03/charts-a1-a2-purple-limits.png"
+      - "/assets/images/day-03/technical-aid-8-control-chart.png"
+    headings:
+      - "Technical Aid 5"
+      - "Technical Aid 6"
+      - "Technical Aid 7"
+      - "Technical Aid 8"
+      - "ACTIVITY 3–g"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "06-six-processes.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-03/six-processes-12-charts.png"
+      - "/assets/images/day-03/six-processes-extended-charts.png"
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "07-a-favourite-example.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-03/favourite-example-run-chart.png"
+      - "/assets/images/day-03/favourite-example-control-chart.png"
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "08-control-chart-and-brain.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-03/worthington-zigzag-sketch.png"
+    headings:
+      - "1. Just below / Just above"
+      - "2. Control limits are (almost) never the same again"
+      - "Technical Aid 9"
+      - "3. Strength of signals"
+      - "4. Subject-matter knowledge"
+      - "5. Control limits are indications, not boundaries"
+      - "6. Other indications"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "09-the-six-processes-revisited.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-03/chart-A3-individual.png"
+      - "/assets/images/day-03/chart-B3-individual.png"
+      - "/assets/images/day-03/chart-C3-individual.png"
+      - "/assets/images/day-03/chart-D3-individual.png"
+      - "/assets/images/day-03/chart-E3-individual.png"
+      - "/assets/images/day-03/chart-F3-individual.png"
+    headings:
+      - "Technical Aid 10"
+      - "Technical Aid 11"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "10-introduction-to-the-funnel-experiment.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-03/funnel-track-basic.png"
+      - "/assets/images/day-03/funnel-track-with-icons.png"
+      - "/assets/images/day-03/funnel-dice-sequences.png"
+      - "/assets/images/day-03/funnel-track-colourful.png"
+    headings: []
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "11-the-first-two-rules-of-the-funnel.qmd"
+    viewof_count: 0
+    figures: []
+    headings:
+      - "The First Two Rules of the Funnel"
+      - "Rule 2 of the Funnel (Ford's First Strategy)"
+      - "Rule 1 of the Funnel (Ford's Second Strategy)"
+      - "Discussion"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "12-rules-3-and-4-of-the-funnel.qmd"
+    viewof_count: 0
+    figures: []
+    headings:
+      - "Rules 3 and 4 of the Funnel"
+      - "Rule 4 of the Funnel"
+    has_download_button: false
+    has_workbook_callout: true
+
+  - file: "13-summary.qmd"
+    viewof_count: 2
+    figures: []
+    headings:
+      - "Summary"
+      - "Four-Rule Comparison"
+      - "Summary Statistics"
+      - "ACTIVITY 3–i"
+      - "ACTIVITY 3–j"
+      - "Start Over with New Dice"
+    has_download_button: true
+    has_workbook_callout: true

--- a/workflow/validation/day-04-manifest.yml
+++ b/workflow/validation/day-04-manifest.yml
@@ -1,0 +1,55 @@
+# Day 4 structural manifest
+# Generated from completed QMD files — baseline for regression checks
+day: 4
+
+chapters:
+  - file: "01-introduction.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-04/joiner-triangle-simple.png"
+    headings:
+      - "DAY 4: THE JOINER TRIANGLE AND THE 14 POINTS (part 1)"
+      - "THE JOINER TRIANGLE"
+      - "Simple and profound"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "02-the-joiner-triangle.qmd"
+    viewof_count: 15
+    figures:
+      - "/assets/images/day-04/joiner-triangle-expanded.png"
+      - "/assets/images/day-04/scientific-approach-box.png"
+      - "/assets/images/day-04/joiner-triangle-combined.png"
+    headings:
+      - "The Joiner Triangle: \"Scientific Approach\""
+      - "ACTIVITY 4–a"
+      - "The Joiner Triangle: \"All One Team\""
+      - "ACTIVITY 4–b"
+      - "The Joiner Triangle: \"Obsession With Quality\""
+      - "PAUSE FOR THOUGHT 4–c"
+      - "ACTIVITY 4–d"
+      - "THE EXPANDED JOINER TRIANGLE"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "03-the-first-project.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-04/first-project-title.png"
+    headings:
+      - "Notes on the First Project"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "04-points-1-to-6.qmd"
+    viewof_count: 18
+    figures: []
+    headings:
+      - "Point 1. Constancy of purpose"
+      - "Point 2. The new philosophy"
+      - "Point 3. Cease dependence on mass inspection"
+      - "Point 4. End lowest-tender contracts"
+      - "Point 5. Improve every process"
+      - "Point 6. Institute training"
+    has_download_button: true
+    has_workbook_callout: true

--- a/workflow/validation/day-05-manifest.yml
+++ b/workflow/validation/day-05-manifest.yml
@@ -1,0 +1,42 @@
+# Day 5 structural manifest
+# Generated from completed QMD files — baseline for regression checks
+day: 5
+
+chapters:
+  - file: "01-introduction.qmd"
+    viewof_count: 0
+    figures:
+      - "/assets/images/day-05/first-project-continued.png"
+    headings:
+      - "DAY 5: THE JOINER TRIANGLE, THE 14 POINTS (part 2), AND THE DEADLY DISEASES"
+    has_download_button: false
+    has_workbook_callout: false
+
+  - file: "02-points-7-to-14.qmd"
+    viewof_count: 24
+    figures:
+      - "/assets/images/day-05/joiner-triangle-bar.png"
+    headings:
+      - "Point 7. Institute leadership of people"
+      - "Point 8. Drive out fear"
+      - "Point 9. Break down barriers"
+      - "Point 10. Eliminate exhortations"
+      - "Point 11. Eliminate arbitrary numerical targets"
+      - "Point 12. Permit pride of workmanship"
+      - "Point 13. Encourage education"
+      - "Point 14. Top management commitment and action"
+    has_download_button: true
+    has_workbook_callout: true
+
+  - file: "03-the-deadly-diseases.qmd"
+    viewof_count: 15
+    figures: []
+    headings:
+      - "Disease 1. Lack of constancy"
+      - "Disease 2. Short-termism"
+      - "Disease 3. Appraisal of performance"
+      - "Disease 4. Management job-hopping"
+      - "Disease 5. Use of only visible figures"
+      - "\"Out-of-hours\" note"
+    has_download_button: true
+    has_workbook_callout: true


### PR DESCRIPTION
## Summary
- Adds `scripts/check-structure.sh` — a bash script that checks each QMD chapter against a per-day manifest and reports PASS/FAIL per check per chapter
- Creates manifest YAML files for all completed days (1–5) in `workflow/validation/`
- Five checks per chapter: viewof declaration count, figure file existence, image reference integrity, section heading match, download button presence, workbook callout presence

Closes #64

## How it works
Manifests declare the expected structural state per chapter. The checker parses them with Ruby (ships with macOS), then inspects the QMD files with grep/diff. Exit code = number of failures, making it CI-friendly.

```bash
./scripts/check-structure.sh 3
```

## Test plan
- [x] Day 1: 76/76 checks pass
- [x] Day 2: 68/68 checks pass
- [x] Day 3: 102/102 checks pass
- [x] Day 4: 27/27 checks pass
- [x] Day 5: 17/17 checks pass
- [x] Clean exit code 0 on all days
- [x] Correct FAIL output when manifest is intentionally altered
- [x] Handles macOS bash 3.2 (no associative arrays)
- [x] Handles macOS Ruby 2.6 (no safe_load_file)
- [x] Handles Unicode curly quotes in headings
- [x] Handles parentheses in image alt text

🤖 Generated with [Claude Code](https://claude.com/claude-code)