### PR TITLE
Harden CI/CD pipeline: permissions, dependabot, build verification

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -119,6 +119,7 @@ jobs:
 
         HTML_COUNT=$(find _book -name "*.html" | wc -l)
         echo "Found $HTML_COUNT HTML files"
+        # Minimum expected HTML files — prevents rsync --delete from wiping production on partial builds
         if [ "$HTML_COUNT" -lt 10 ]; then
           echo "FAIL: Build produced fewer than 10 HTML files — aborting deploy"
           exit 1

--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy (Optimized)
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -113,6 +116,13 @@ jobs:
       run: |
         echo "Checking index.html exists..."
         test -f _book/index.html || { echo "FAIL: _book/index.html missing"; exit 1; }
+
+        HTML_COUNT=$(find _book -name "*.html" | wc -l)
+        echo "Found $HTML_COUNT HTML files"
+        if [ "$HTML_COUNT" -lt 10 ]; then
+          echo "FAIL: Build produced fewer than 10 HTML files — aborting deploy"
+          exit 1
+        fi
 
         echo "Checking converted days..."
         for day_dir in content/days/day-*/; do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,6 +130,7 @@ jobs:
 
         HTML_COUNT=$(find _book -name "*.html" | wc -l)
         echo "Found $HTML_COUNT HTML files"
+        # Minimum expected HTML files — prevents rsync --delete from wiping production on partial builds
         if [ "$HTML_COUNT" -lt 10 ]; then
           echo "FAIL: Build produced fewer than 10 HTML files — aborting deploy"
           exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy (Current)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -124,6 +127,13 @@ jobs:
       run: |
         echo "Checking index.html exists..."
         test -f _book/index.html || { echo "FAIL: _book/index.html missing"; exit 1; }
+
+        HTML_COUNT=$(find _book -name "*.html" | wc -l)
+        echo "Found $HTML_COUNT HTML files"
+        if [ "$HTML_COUNT" -lt 10 ]; then
+          echo "FAIL: Build produced fewer than 10 HTML files — aborting deploy"
+          exit 1
+        fi
 
         echo "Checking converted days..."
         for day_dir in content/days/day-*/; do

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ issues/
 **/*.quarto_ipynb
 
 docs/context/analysis/
+
+venv/
+temp/


### PR DESCRIPTION
## Summary
- **#20**: Add top-level `permissions: contents: read` to both deploy workflows, limiting default GITHUB_TOKEN scope. The `build-and-deploy` job in `deploy.yml` retains its existing `contents: write` override (needed for `git push --tags`).
- **#21**: Add `venv/` and `temp/` to `.gitignore` for defense in depth (neither directory has tracked files).
- **#23**: Add `.github/dependabot.yml` for weekly GitHub Actions dependency scanning.
- **#24**: Add minimum HTML file count check (≥10) to the smoke test in both workflows, preventing `rsync --delete` from wiping production if a build produces empty/partial output.

Closes #20, #21, #23, #24

## Test plan
- [ ] Verify `deploy.yml` YAML is valid and CI runs pass
- [ ] Verify `deploy-optimized.yml` YAML is valid
- [ ] Confirm Dependabot creates its first scan after merge
- [ ] Confirm `.gitignore` additions don't affect tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)