### PR TITLE
Add retroactive conversion briefs for Days 1-2

### DIFF
--- a/workflow/briefs/day-01-brief.yml
+++ b/workflow/briefs/day-01-brief.yml
@@ -1,0 +1,210 @@
+# ============================================================
+# Day 1 Brief — The Overture (retroactive)
+# ============================================================
+# Created: 2026-04-16 (retroactive — documenting existing conversion)
+# Day 1 was converted before the brief system was introduced.
+# This brief reconstructs the chapter-to-page mapping from the
+# finished QMD files and source PDF.
+# ============================================================
+
+# ------ Day Metadata ------
+day:
+  number: 1
+  title: "The Overture"
+  source_prefix: "D.Day.1.07Feb22"
+  page_count: 50
+
+# ------ Page Mapping ------
+# Day 1 source PNGs do NOT exist in 12-Days-to-Deming/PNGs/.
+# The conversion was done before the PNG workflow was established.
+# Page numbers below are ESTIMATED printed page numbers based on
+# content alignment with the PDF. The PDF has 50 pages total;
+# front matter (title, blank, TOC) likely occupies pages 1-4,
+# giving printed pages 1-46.
+#
+# Because the source PNGs are unavailable, page ranges are
+# approximate and cannot be verified against images.
+
+# ------ Chapter Plan ------
+# 13 chapters covering the full day (morning + afternoon sessions).
+# The morning session (chapters 01-10) runs through introductory
+# and contextual material. The afternoon session (chapters 11-13)
+# covers The Deming Story and the first Major Activity.
+
+chapters:
+  - slug: "overture"
+    title: "DAY 1 (morning): THE OVERTURE"
+    pages: "1-2"
+    notes: |
+      Opening page with Dr Deming and Dr Neave photo (day_1_fig_1.jpg).
+      Clock at 9:30. Sets the scene for the course.
+    interactive: "none"
+
+  - slug: "rediscovered"
+    title: "DEMING (RE)DISCOVERED"
+    pages: "3-8"
+    notes: |
+      Historical overview of Deming's rediscovery by Western industry.
+      Photos: William E Conway (day_1_fig_2.png), Deming Medal
+      (day_1_fig_3.jpg), Dr Lloyd S Nelson (day_1_fig_4.png),
+      Dr Walter A Shewhart (day_1_fig_5.png). Clock at 9:40.
+    interactive: "none"
+
+  - slug: "statistics"
+    title: "'STATISTICS? OH NO!'"
+    pages: "9-13"
+    notes: |
+      Reassurance about the statistical content of the course.
+      Three stats levels (0, 1, 2) explained.
+      Clocks at 9:55, 10:00, 10:10.
+    interactive: "none"
+
+  - slug: "resources"
+    title: "HELPFUL BOOKS AND VIDEOS"
+    pages: "14-16"
+    notes: |
+      Reading list and video resources. Clock at 10:25.
+    interactive: "none"
+
+  - slug: "activities"
+    title: "ACTIVITIES, MAJOR ACTIVITIES, PAUSES FOR THOUGHT, PROJECTS AND 'YOUR ORGANISATION'"
+    pages: "17-19"
+    notes: |
+      Explains the interactive element types used throughout the course.
+      Clock at 10:35.
+    interactive: "none"
+
+  - slug: "outline"
+    title: "OUTLINE OF THE COURSE"
+    pages: "20-24"
+    notes: |
+      Overview of all 12 days. Clock at 10:55.
+    interactive: "none"
+
+  - slug: "quality-theory"
+    title: "QUALITY, THEORY, PHILOSOPHY, MANAGEMENT,..."
+    pages: "25-30"
+    notes: |
+      First substantive content section. Contains Pauses for Thought
+      1-a, 1-b, 1-c. Two workbook callouts (WB pages 1, 2).
+      Clocks at 11:10, 11:20, 11:25, 11:35. Download button for
+      thoughts 1a/1b/1c.
+    interactive: "3 Pauses for Thought (viewof thought_1a, thought_1b, thought_1c), 1 download button"
+
+  - slug: "attraction"
+    title: "THE ATTRACTION OF DEMING'S WORK"
+    pages: "31-35"
+    notes: |
+      Activity 1-d (WB page 3) and Activity 1-e (WB page 4).
+      The "dissatisfied callers" number input exercise.
+      Clocks at 11:45, 12:00, 12:10. Download button for
+      activities 1d/1e.
+    interactive: "2 activities (viewof activity_1d, activity_1e_1, activity_1e_2), 1 download button"
+
+  - slug: "different"
+    title: "DEMING IS DIFFERENT"
+    pages: "36-38"
+    notes: |
+      Distinguishes Deming's approach from other quality gurus.
+      Clock at 12:25.
+    interactive: "none"
+
+  - slug: "relief"
+    title: "SOME LIGHT RELIEF"
+    pages: "39"
+    notes: |
+      Brief humorous interlude before lunch. Clock at 12:30.
+    interactive: "none"
+
+  - slug: "deming-story"
+    title: "DAY 1 (afternoon): THE DEMING STORY"
+    pages: "40-46"
+    notes: |
+      Biographical narrative of Deming's life and career.
+      Photos: Ken-ichi Koyanagi with Dr Deming (day_1_fig_6.png),
+      Japan's Second Order Medal of the Sacred Treasure
+      (day_1_fig_7.png). Clocks at 1:30, 1:40, 2:20, 2:30,
+      2:50, 3:30. Longest chapter in Day 1.
+    interactive: "none"
+
+  - slug: "intro-activity"
+    title: "INTRODUCTION TO THE MAJOR ACTIVITY"
+    pages: "47"
+    notes: |
+      Sets up Major Activity 1-f. Clock at 3:40.
+    interactive: "none"
+
+  - slug: "major-activity"
+    title: "MAJOR ACTIVITY 1-f"
+    pages: "48-50"
+    notes: |
+      Final chapter. 10 paired textareas (a/b for items 1-10)
+      covering Deming's key teachings. Workbook callout referencing
+      WB pages 5-7. Download button for all 20 viewof fields.
+      Most interactive chapter of Day 1.
+    interactive: "21 viewof fields (10 pairs + extras), 1 download button"
+
+# ------ Figure Decisions ------
+# Day 1 images use legacy naming (day_1_fig_N) rather than the
+# descriptive naming convention adopted from Day 3 onward.
+
+figures:
+  - page: 1
+    action: "existing"
+    notes: "Dr Deming and Dr Neave photo → day_1_fig_1.jpg"
+
+  - page: 4
+    action: "existing"
+    notes: "William E Conway photo → day_1_fig_2.png"
+
+  - page: 5
+    action: "existing"
+    notes: "Deming Medal photo → day_1_fig_3.jpg"
+
+  - page: 7
+    action: "existing"
+    notes: "Dr Lloyd S Nelson photo → day_1_fig_4.png"
+
+  - page: 8
+    action: "existing"
+    notes: "Dr Walter A Shewhart photo → day_1_fig_5.png"
+
+  - page: 43
+    action: "existing"
+    notes: "Ken-ichi Koyanagi with Dr Deming → day_1_fig_6.png"
+
+  - page: 45
+    action: "existing"
+    notes: "Japan's Second Order Medal of the Sacred Treasure → day_1_fig_7.png"
+
+# ------ Context Notes ------
+context_notes: |
+  Day 1 was the first day converted and predates the structured
+  5-phase workflow. Key differences from later days:
+
+  1. Source PNGs do not exist — the PDF was used directly during
+     the original conversion. Page numbers in this brief are
+     estimates based on content alignment; they cannot be verified
+     against source images.
+
+  2. Image naming uses legacy convention (day_1_fig_N) rather
+     than the descriptive names adopted from Day 3 onward.
+
+  3. The morning/afternoon split is reflected in the chapter
+     titles ("Day 1 (morning)" and "Day 1 (afternoon)").
+
+  4. Cross-references to other materials:
+     - Workbook pages 1-7 referenced (WB callouts in chapters
+       07, 08, 13)
+     - Appendix page 6 referenced in chapter 07
+       (appendix.html#sec-page6)
+     - DemDim, Out of the Crisis, and The New Economics cited
+       throughout
+
+  5. No clocks appear in Day 2, but Day 1 uses them extensively
+     (20+ clock indicators across the day).
+
+  Gaps: No pages appear to be missing from coverage. The 13
+  chapters span the full 50-page PDF. The only content excluded
+  would be front matter (title page, TOC) and any trailing
+  blank pages.

--- a/workflow/briefs/day-02-brief.yml
+++ b/workflow/briefs/day-02-brief.yml
@@ -163,7 +163,19 @@ figures:
 
   - page: 35
     action: "existing"
-    notes: "Week 1-4 Spaniards' results → image-11 through image-14.png"
+    notes: "Week 1 Spaniards' results → image-11.png"
+
+  - page: 36
+    action: "existing"
+    notes: "Week 2 Spaniards' results → image-12.png"
+
+  - page: 37
+    action: "existing"
+    notes: "Week 3 Spaniards' results → image-13.png"
+
+  - page: 38
+    action: "existing"
+    notes: "Week 4 Spaniards' results → image-14.png"
 
   - page: 40
     action: "existing"

--- a/workflow/briefs/day-02-brief.yml
+++ b/workflow/briefs/day-02-brief.yml
@@ -1,0 +1,207 @@
+# ============================================================
+# Day 2 Brief — The Experiment on Red Beads (retroactive)
+# ============================================================
+# Created: 2026-04-16 (retroactive — documenting existing conversion)
+# Day 2 was converted before the brief system was introduced.
+# This brief reconstructs the chapter-to-page mapping from the
+# finished QMD files and source PDF.
+# ============================================================
+
+# ------ Day Metadata ------
+day:
+  number: 2
+  title: "The Experiment on Red Beads"
+  source_prefix: "E.Day.2.12Oct21"
+  page_count: 44
+
+# ------ Page Mapping ------
+# Source PNGs exist at 12-Days-to-Deming/PNGs/E.Day.2.12Oct21_page_NNN.png
+# (44 files, pages 005-048 — suggesting 4 pages of front matter).
+#
+# Page offset: printed_page = png_page - 4
+# (4 pages of front matter: title, blank, TOC pages)
+#
+# Page numbers below are ESTIMATED printed page numbers based on
+# content in the QMD files. Without a Phase 1 recon, these are
+# approximate but informed by workbook callouts and content flow.
+
+# ------ Chapter Plan ------
+# 9 chapters covering the full day. The Red Beads Experiment is
+# the centrepiece, with run charts as warm-up and a postscript
+# closing.
+
+chapters:
+  - slug: "run-charts"
+    title: "RUN CHARTS"
+    pages: "1-5"
+    notes: |
+      Opening section reviewing run charts. Includes a run chart
+      image (Picture 1.jpg) showing declining values. Pause for
+      Thought 2-a (WB page 9). Download button.
+    interactive: "1 Pause for Thought (viewof thought_2a), 1 download button"
+
+  - slug: "intro-to-the-red-beads-experiment"
+    title: "INTRODUCTION TO THE RED BEADS EXPERIMENT"
+    pages: "6-8"
+    notes: |
+      Sets up the Red Beads Experiment. Pause for Thought 2-b
+      (WB page 10) and Pause for Thought 2-c (WB page 11).
+      Six viewof fields (5 text inputs for worker names + 1
+      textarea). Download button.
+    interactive: "6 viewof fields (thought_2b, thought_2c, 4 text inputs), 1 download button"
+
+  - slug: "a-brief-overview"
+    title: "A BRIEF OVERVIEW"
+    pages: "9-12"
+    notes: |
+      Overview of the experiment mechanics. Handwritten results
+      table image (image-2.png) shown twice (in-flow and in a
+      float-box). Pause for Thought 2-d (WB pages 12-13).
+      Download button.
+    interactive: "1 Pause for Thought (viewof thought_2d), 1 download button"
+
+  - slug: "our-first-control-chart"
+    title: "OUR FIRST CONTROL CHART"
+    pages: "13-14"
+    notes: |
+      Introduction to control charts using Red Beads data. Pause
+      for Thought 2-e (WB page 13). Download button.
+      No images — control chart is generated in R.
+    interactive: "1 Pause for Thought (viewof thought_2e), 1 download button"
+
+  - slug: "the-truth-the-whole-truth-and-nothing-but"
+    title: "THE TRUTH, THE WHOLE TRUTH, AND NOTHING BUT ..."
+    pages: "15-21"
+    notes: |
+      Deep dive into what the Red Beads Experiment teaches.
+      Photo of Red Beads apparatus (image-4.jpg). Workbook
+      callout. No viewof fields (drawing pad mentioned in
+      callout but no textarea).
+    interactive: "none"
+
+  - slug: "your-turn"
+    title: "YOUR TURN"
+    pages: "22-27"
+    notes: |
+      Activity 2-f (WB pages 14-19). The user runs their own
+      version of the Red Beads Experiment. 20 viewof fields
+      (number inputs for Red Beads data entry — 6 workers x
+      4 weeks, plus totals and calculations). Heavy interactive
+      chapter with R-generated tables and control charts.
+    interactive: "20 viewof fields (number inputs for data entry)"
+
+  - slug: "some-recollections"
+    title: "SOME RECOLLECTIONS"
+    pages: "28-37"
+    notes: |
+      Activity 2-g (WB pages 20-25). Recollections of real Red
+      Beads experiments. The most figure-heavy chapter: 10 images
+      (image-5.jpg through image-14.png) showing results tables
+      from professional statisticians and Spanish participants.
+      12 viewof fields. Longest chapter of Day 2.
+    interactive: "12 viewof fields, no download button"
+
+  - slug: "major-activity"
+    title: "MAJOR ACTIVITY"
+    pages: "38-39"
+    notes: |
+      Major Activity 2-h (WB pages 26-29). Workbook callout
+      references Appendix pages 1-5. 2 viewof fields (textareas
+      for user responses).
+    interactive: "2 viewof fields (textareas)"
+
+  - slug: "postscript"
+    title: "POSTSCRIPT"
+    pages: "40"
+    notes: |
+      Brief closing section. Spanish Red Beads Experiment results
+      table (postscript-table.png). No interactive elements. No
+      workbook callout. Final page of Day 2 content.
+    interactive: "none"
+
+# ------ Figure Decisions ------
+# Day 2 images use legacy naming (Picture 1.jpg, image-N.ext)
+# rather than the descriptive naming convention adopted from
+# Day 3 onward.
+
+figures:
+  - page: 2
+    action: "existing"
+    notes: "Run chart of declining values → Picture 1.jpg"
+
+  - page: 10
+    action: "existing"
+    notes: "Handwritten Red Beads results table → image-2.png"
+
+  - page: 16
+    action: "existing"
+    notes: "Red Beads apparatus photo → image-4.jpg"
+
+  - page: 28
+    action: "existing"
+    notes: "Professional statisticians' results table → image-5.jpg"
+
+  - page: 29
+    action: "existing"
+    notes: "Spaniards' results table → image-6.png"
+
+  - page: 30
+    action: "existing"
+    notes: "Week 1 professional statisticians → image-7.png"
+
+  - page: 31
+    action: "existing"
+    notes: "Week 2 professional statisticians → image-8.png"
+
+  - page: 32
+    action: "existing"
+    notes: "Week 3 professional statisticians → image-9.png"
+
+  - page: 33
+    action: "existing"
+    notes: "Week 4 professional statisticians → image-10.png"
+
+  - page: 35
+    action: "existing"
+    notes: "Week 1-4 Spaniards' results → image-11 through image-14.png"
+
+  - page: 40
+    action: "existing"
+    notes: "Spanish Red Beads Experiment results → postscript-table.png"
+
+# ------ Context Notes ------
+context_notes: |
+  Day 2 was converted early in the project, before the structured
+  5-phase workflow. Key differences from later days:
+
+  1. Source PNGs exist (E.Day.2.12Oct21_page_NNN.png, 44 files)
+     but no Phase 1 recon was performed. Page ranges in this brief
+     are estimates based on content and workbook callout references.
+
+  2. Image naming uses legacy convention (Picture 1.jpg, image-N)
+     rather than the descriptive names adopted from Day 3 onward.
+
+  3. No clocks are used in Day 2 (unlike Day 1 which has 20+).
+
+  4. The Red Beads data entry (chapter 06, "Your Turn") is the
+     first major interactive R-powered section in the book — users
+     enter their own experimental data and see generated control
+     charts.
+
+  5. Cross-references:
+     - Appendix pages 1-5 referenced in Major Activity 2-h
+     - Red Beads data and concepts are referenced heavily in
+       Days 3-12
+     - Sales data from Day 2 is revisited on Day 3 page 14
+
+  6. Download buttons appear in chapters 01-04 only. Chapters
+     05-09 lack download buttons — this may be an inconsistency
+     from the early conversion.
+
+  Gaps: Pages 41-44 of the PDF are likely blank/end matter and
+  are not covered by any chapter. All substantive content appears
+  to be accounted for across the 9 chapters.
+
+  Page coverage summary:
+    Pages 1-40: covered by chapters 01-09
+    Pages 41-44: presumed blank/end matter (not covered)


### PR DESCRIPTION
## Summary
- Adds `workflow/briefs/day-01-brief.yml` and `workflow/briefs/day-02-brief.yml`
- Days 1-2 were converted before the brief system existed; these retroactive briefs reconstruct the chapter-to-page mapping from the finished QMD files
- Follows the same YAML schema as the existing Days 3-12 briefs
- Page ranges are estimated (Day 1 has no source PNGs; Day 2 PNGs exist but no Phase 1 recon was performed)

Closes #70

## Test plan
- [ ] Verify YAML is valid (`ruby -ryaml -e 'YAML.load_file("workflow/briefs/day-01-brief.yml")'`)
- [ ] Confirm chapter slugs match the QMD filenames in `content/days/day-01/` and `day-02/`
- [ ] Confirm interactive element counts align with QMD content

🤖 Generated with [Claude Code](https://claude.com/claude-code)