### PR TITLE
Fix code quality issues: spacers, library loading, download guard, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ When extracting tables, charts, photos, or other figures from original PDF mater
 ### Usage in Quarto
 Reference cropped images in `.qmd` files:
 ```markdown
-![Description](/assets/images/day-XX/filename.png){.lightbox}
+![Description](/assets/images/day-XX/filename.png)
 ```
 
 ## Deployment Architecture

--- a/R/functions/main-functions.R
+++ b/R/functions/main-functions.R
@@ -1,6 +1,7 @@
 library(ggplot2)
 library(dplyr)
 library(gt)
+library(DiagrammeR)
 
 # --- Named constants ---
 

--- a/assets/scripts/functions.js
+++ b/assets/scripts/functions.js
@@ -9,9 +9,15 @@ export function createDownloadButton(inputs, fileName) {
 
 export function downloadNotes(inputs, fileName) {
   const combinedText = combineInputValues(inputs);
+
+  if (!combinedText.replace(/[\s—-]+/g, "").length) {
+    alert("You haven't written any notes yet. Fill in at least one field before downloading.");
+    return;
+  }
+
   const blob = createTextBlob(combinedText);
   const url = URL.createObjectURL(blob);
-  
+
   triggerDownload(url, fileName);
   cleanupUrl(url);
 }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -255,6 +255,13 @@ Usage:
 /* ===== UTILITY CLASSES ===== */
 .mt-sm { margin-top: 10px; }
 .mt-md { margin-top: 20px; }
+.spacer-sm  { margin-top: 50px; }
+.spacer-md  { margin-top: 100px; }
+.spacer-lg  { margin-top: 175px; }
+.spacer-xl  { margin-top: 300px; }
+.spacer-2xl { margin-top: 400px; }
+.spacer-3xl { margin-top: 600px; }
+.spacer-4xl { margin-top: 1300px; }
 .text-highlight-red { color: var(--color-outcome); font-weight: bold; }
 .data-sequence-mono { text-align: center; font-family: monospace; }
 .table-cell-highlight { background: var(--color-highlight-green); font-weight: bold; }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -345,6 +345,11 @@ Usage:
     padding: 15px;
   }
   
+  /* Large spacers: reduce on mobile to avoid huge blank gaps */
+  .spacer-2xl { margin-top: 100px; }
+  .spacer-3xl { margin-top: 150px; }
+  .spacer-4xl { margin-top: 200px; }
+
   /* Activity titles */
   .major_activity_title {
     margin: 15px auto;

--- a/content/days/day-01/02-rediscovered.qmd
+++ b/content/days/day-01/02-rediscovered.qmd
@@ -131,7 +131,7 @@ before Dr Deming resumed his teaching. However, he was always there: watching, l
 :::
   
 ::: {.column width="15%"}
-<div style="margin-top: 170px">
+<div class="spacer-lg">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(9, 40)
 ```

--- a/content/days/day-01/03-statistics.qmd
+++ b/content/days/day-01/03-statistics.qmd
@@ -104,7 +104,7 @@ keep flitting between alternative terms for the same thing.</span>
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 290px">
+<div class="spacer-xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(9, 55)
 ```
@@ -179,7 +179,7 @@ about it! Makes good sense to me. And that is precisely what Dr Shewhart produce
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 400px">
+<div class="spacer-2xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(10, 00)
 ```
@@ -313,7 +313,7 @@ guidance on timings at all closely then please “stop the clock” whilst you a
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 40px">
+<div class="spacer-sm">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(10, 10)
 ```

--- a/content/days/day-01/04-resources.qmd
+++ b/content/days/day-01/04-resources.qmd
@@ -133,7 +133,7 @@ his work in that country in the summer of 1950—see today’s [page 35](#sec-pa
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 130px">
+<div class="spacer-lg">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(10, 25)
 ```

--- a/content/days/day-01/05-activities.qmd
+++ b/content/days/day-01/05-activities.qmd
@@ -75,7 +75,7 @@ you with a “surrogate” organisation to use in your study!
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 300px">
+<div class="spacer-xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(10, 35)
 ```

--- a/content/days/day-01/06-outline.qmd
+++ b/content/days/day-01/06-outline.qmd
@@ -167,7 +167,7 @@ the end of the 12th day! Perhaps I should have simply titled Day 12 as “The En
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 100px">
+<div class="spacer-md">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(10, 55)
 ```

--- a/content/days/day-01/07-quality-theory.qmd
+++ b/content/days/day-01/07-quality-theory.qmd
@@ -55,7 +55,7 @@ top management runs the company—and how the company is run depends on top mana
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 400px">
+<div class="spacer-2xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(11, 10)
 ```
@@ -90,7 +90,7 @@ viewof thought_1b = Inputs.textarea({label: "Why does managing by results reduce
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 400px">
+<div class="spacer-2xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(11, 20)
 ```
@@ -120,7 +120,7 @@ viewof thought_1c = Inputs.textarea({label: "Why might the word quality provoke 
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 580px">
+<div class="spacer-3xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(11, 25)
 ```
@@ -180,7 +180,7 @@ these words are of fundamental importance.
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 100px">
+<div class="spacer-md">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(11, 35)
 ```

--- a/content/days/day-01/08-attraction.qmd
+++ b/content/days/day-01/08-attraction.qmd
@@ -83,7 +83,7 @@ some thoughts that might help you to make some useful connections as the course 
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 600px">
+<div class="spacer-3xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(12, 00)
 ```
@@ -143,7 +143,7 @@ viewof activity_1e_2 = Inputs.number([10, 0], {step: 1, label: "Dissatisfied cal
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 1300px">
+<div class="spacer-4xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(12, 10)
 ```

--- a/content/days/day-01/09-different.qmd
+++ b/content/days/day-01/09-different.qmd
@@ -90,7 +90,7 @@ only more people—especially those in management and government—had listened 
 :::
 
 ::: {.column width="15%"}
-<div style="margin-top: 250px">
+<div class="spacer-xl">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(12, 25)
 ```

--- a/content/days/day-01/11-deming-story.qmd
+++ b/content/days/day-01/11-deming-story.qmd
@@ -255,7 +255,7 @@ What did he mean by <span class=deming_quote>“the theory of a system, and coop
 
 ::: {.column width="15%"}
 
-<div style="margin-top: 100px">
+<div class="spacer-md">
 
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(2, 30)
@@ -274,8 +274,6 @@ create_clock(2, 30)
 </span>
 
 ```{r day1_flowchart1}
-
-library(DiagrammeR)
 
 grViz("
   digraph flowchart {
@@ -522,12 +520,9 @@ inter-depend. This is a *rich* legacy.
 :::
 
 ::: {.column width="50%"}
-<div style="margin-top: 50px">
+<div class="spacer-sm">
 ```{r day1_plot}
 #| crop: true
-
-# Load necessary libraries
-library(ggplot2)
 
 # Create a data frame for the rectangles and their labels
 rectangles <- data.frame(

--- a/content/days/day-01/12-intro-activity.qmd
+++ b/content/days/day-01/12-intro-activity.qmd
@@ -48,7 +48,7 @@ this opening day of our *12 Days to Deming*.
 :::
   
 ::: {.column width="15%"}
-<div style="margin-top: 80px">
+<div class="spacer-md">
 ```{r, echo=FALSE, message=FALSE, warning=FALSE}
 create_clock(3, 40)
 ```


### PR DESCRIPTION
## Summary

- **#122**: Replace 17 inline `margin-top` styles in Day 1 QMD files with 7 reusable CSS utility classes (`spacer-sm` through `spacer-4xl`). Values bucketed into tiers since these simulate PDF page breaks and don't need pixel-perfect fidelity.
- **#58**: Move `library(DiagrammeR)` and `library(ggplot2)` from `11-deming-story.qmd` to `main-functions.R` so all package loading is centralised. Zero `library()` calls remain in QMD files.
- **#72**: Add empty-content guard to `downloadNotes()` — shows an alert instead of downloading a blank file when all input fields are empty.
- **#60**: Remove nonexistent `{.lightbox}` class from CLAUDE.md image example.
- **#123**: Investigated and found the file (`day-06/04-more-true-stories.qmd`) contains zero `<div>` elements — no thought divs exist to add ARIA roles to. Closing as not applicable.

Closes #58, closes #60, closes #72, closes #122, closes #123

## Test plan

- [x] All 55 JS tests pass (`npm test`)
- [x] All 33 R tests pass (`testthat::test_dir`)
- [x] Zero inline `margin-top` styles remain in Day 1
- [x] Zero `library()` calls remain in QMD content files
- [ ] CI build passes
- [ ] Verify spacer visual appearance hasn't regressed significantly on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)