### PR TITLE
Fix high-priority markup and download button bugs

### DIFF
--- a/content/days/day-08/06-major-activity.qmd
+++ b/content/days/day-08/06-major-activity.qmd
@@ -3,7 +3,7 @@ title: "MAJOR ACTIVITY 8-d"
 execute:
   echo: false
 ---
-<div class="major_activity_title">MAJOR ACTIVITY 8–d</div>
+<div class="major_activity_title"><h2>MAJOR ACTIVITY 8–d</h2></div>
 
 ## TABLE ONE
 

--- a/content/days/day-09/04-major-activity.qmd
+++ b/content/days/day-09/04-major-activity.qmd
@@ -5,7 +5,7 @@ execute:
 ---
 <div class="workbook_callout" role="note" aria-label="Workbook reference">Major Activity 9–e (pages 11–15) is also on Workbook pages 144–148.</div>
 
-<div class="major_activity_title">MAJOR ACTIVITY 9–e</div>
+<div class="major_activity_title"><h2>MAJOR ACTIVITY 9–e</h2></div>
 
 With what you have learned this morning fresh in mind, it is now time for you to try to develop a "macro" flow diagram of your organisation. To prepare the ground for that, I will quote in advance an extract in Dr Deming's own words from Day 10:
 

--- a/content/days/day-10/02-appreciation-for-a-system.qmd
+++ b/content/days/day-10/02-appreciation-for-a-system.qmd
@@ -228,4 +228,16 @@ For your later reference (but not now!), the sections of *The New Economics* mos
   </div>
 </div>
 
+```{ojs download_all_10_parta}
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
+
+createDownloadButton([
+  viewof note_10_components, viewof note_10_aim,
+  viewof note_10_optimisation, viewof note_10_aide_flowdiagram,
+  viewof note_10_orchestra_business, viewof note_10_schools_performance,
+  viewof note_10_poor_management, viewof note_10_winlose,
+  viewof note_10_suboptimisation_taguchi, viewof note_10_demdim_parta
+], "notes_10_appreciation_for_a_system.txt")
+```
+
 *(After the break, continue to Activity 10-a overleaf.)*

--- a/content/days/day-10/04-theory-of-variation.qmd
+++ b/content/days/day-10/04-theory-of-variation.qmd
@@ -184,6 +184,17 @@ viewof note_10_demdim_partb = Inputs.textarea({placeholder: "Additional notes fr
 The section of *The New Economics* Chapter 4 relating to Part B is pages 67–69[98–101]. However, there is much more: indeed, all of the book's final four chapters (other than the additional final chapter in the Third Edition) are also immediately relevant.
 </div>
 
+```{ojs download_all_10_partb}
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
+
+createDownloadButton([
+  viewof note_10_variation_12, viewof note_10_capability_leadership,
+  viewof note_10_measurement_mistakes, viewof note_10_shewhart_interaction,
+  viewof note_10_enumerative_analytic, viewof note_10_loss_random,
+  viewof note_10_committee_outside, viewof note_10_demdim_partb
+], "notes_10_theory_of_variation.txt")
+```
+
 <div class="separator">
   <div class="separator_white">
   <div class="separator_blue"></div>

--- a/content/days/day-11/02-theory-of-knowledge-prediction.qmd
+++ b/content/days/day-11/02-theory-of-knowledge-prediction.qmd
@@ -122,6 +122,15 @@ Now briefly read through *DemDim* page 274, paragraph 1 to page 275, paragraph 4
 viewof note_11_demdim_area1 = Inputs.textarea({placeholder: "Additional notes from DemDim pages 274–275.", rows: 6})
 ```
 
+```{ojs download_all_11_area1}
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
+
+createDownloadButton([
+  viewof note_11_prediction_1, viewof note_11_prediction_2,
+  viewof note_11_prediction_3, viewof note_11_demdim_area1
+], "notes_11_prediction.txt")
+```
+
 <div class="separator">
   <div class="separator_white">
   <div class="separator_blue"></div>

--- a/content/days/day-11/03-theory-of-knowledge-theory-and-learning.qmd
+++ b/content/days/day-11/03-theory-of-knowledge-theory-and-learning.qmd
@@ -104,6 +104,15 @@ Now briefly read through *DemDim* pages 275--276, paragraphs 5 to 7 again, as us
 viewof note_11_demdim_area2 = Inputs.textarea({placeholder: "Additional notes from DemDim pages 275–276.", rows: 6})
 ```
 
+```{ojs download_all_11_area2}
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
+
+createDownloadButton([
+  viewof note_11_theory_4, viewof note_11_theory_5,
+  viewof note_11_theory_6, viewof note_11_demdim_area2
+], "notes_11_theory_and_learning.txt")
+```
+
 <div class="separator">
   <div class="separator_white">
   <div class="separator_blue"></div>

--- a/content/days/day-11/04-theory-of-knowledge-operational-definitions.qmd
+++ b/content/days/day-11/04-theory-of-knowledge-operational-definitions.qmd
@@ -109,6 +109,16 @@ viewof note_11_demdim_partc_complete = Inputs.textarea({placeholder: "Final note
 For your future reference, the section of Chapter 4 in <em>The New Economics</em> which relates to Part C runs from the middle of page 69[bottom of page 101] to page 72[107].
 </div>
 
+```{ojs download_all_11_area3}
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
+
+createDownloadButton([
+  viewof note_11_opdef_7, viewof note_11_opdef_8,
+  viewof note_11_opdef_9, viewof note_11_demdim_area3,
+  viewof note_11_demdim_partc_complete
+], "notes_11_operational_definitions.txt")
+```
+
 <div class="separator">
   <div class="separator_white">
   <div class="separator_blue"></div>

--- a/content/days/day-11/06-knowledge-of-psychology.qmd
+++ b/content/days/day-11/06-knowledge-of-psychology.qmd
@@ -224,6 +224,19 @@ viewof note_11_demdim_partd = Inputs.textarea({placeholder: "Additional notes fr
 For your future reference, the section of <em>The New Economics</em> Chapter 4 relating to Part D is on pages 73--78[107--115].
 </div>
 
+```{ojs download_all_11_partd}
+import { createDownloadButton } from "../../../assets/scripts/functions.js"
+
+createDownloadButton([
+  viewof note_11_psych_1, viewof note_11_psych_2,
+  viewof note_11_psych_3, viewof note_11_psych_4,
+  viewof note_11_psych_5a, viewof note_11_psych_5b,
+  viewof note_11_psych_5c, viewof note_11_psych_5d,
+  viewof note_11_psych_5e, viewof note_11_psych_5f,
+  viewof note_11_demdim_partd
+], "notes_11_knowledge_of_psychology.txt")
+```
+
 *(Continue to Activity 11-b overleaf.)*
 
 <div class="separator">

--- a/content/days/day-12/02-your-radar-diagram.qmd
+++ b/content/days/day-12/02-your-radar-diagram.qmd
@@ -16,7 +16,7 @@ Activity 12–a, Part 1 is also on Workbook page 215.
 
 <div class="thought_commentary">
 
-# ACTIVITY 12–a, Part 1
+## ACTIVITY 12–a, Part 1
 
 Your first task is simply to collect together all of your 0--5 scores from Activities 10a–b and 11a–b into the table on page 4. If you haven't printed out an extra copy of that table (suggested on Day 11 page 36), it will make life easier if you temporarily detach that page so that you won't have to keep turning back to it. (The table is deliberately set on a left-hand page because it will be convenient for you to have the table and the radar diagram on facing pages in the third part of this Activity.)
 
@@ -32,7 +32,7 @@ As with Part 1 of this Activity, Part 2 is also on Workbook page 215.
 
 <div class="thought_commentary">
 
-# ACTIVITY 12–a, Part 2
+## ACTIVITY 12–a, Part 2
 
 So now choose your 19 combinations of colours and line styles and indicate them in the KEY column on page 4, one against each of the 14 Points and each of the five Deadly Diseases. For example, if you've decided that your four-line shape for Point 1 (Create Constancy of Purpose) is to be drawn with broken green lines: −−−−−− as in the diagram on page 3, indicate that as I've shown in the KEY column on page 4.
 
@@ -50,7 +50,7 @@ Activity 12–a, Part 3 is also on Workbook page 215.
 
 <div class="thought_commentary">
 
-# ACTIVITY 12–a, Part 3
+## ACTIVITY 12–a, Part 3
 
 Ready, go! Using your chosen KEYs in turn, carry out this procedure on the large radar diagram below, illustrating your scores that you've recorded in the table for all the 14 Points and five Deadly Diseases.
 

--- a/content/days/day-12/03-wisdom-from-peter-scholtes.qmd
+++ b/content/days/day-12/03-wisdom-from-peter-scholtes.qmd
@@ -40,7 +40,7 @@ Activity 12–b is also on Workbook page 218.
 
 <div class="thought_commentary">
 
-# ACTIVITY 12–b
+## ACTIVITY 12–b
 
 Following some of the guidance on page 8---and anything else that comes into your mind---now try to identify a few of the important connections between pairs of the four parts of the System of Profound Knowledge and write them in on Peter Scholtes's diagram below.
 


### PR DESCRIPTION
## Summary
- **Day 12 heading levels** (#149): Changed 4 activity headings from H1 (`#`) to H2 (`##`) inside content divs, restoring proper document outline hierarchy
- **Days 8-9 major activity title** (#150): Wrapped title text in `<h2>` tags so the `.major_activity_title h2` CSS selector applies correctly (DM Serif Display font, proper padding)
- **Days 10-11 download buttons** (#148): Added `createDownloadButton` to 6 study note pages (2 in Day 10, 4 in Day 11) so users can save their typed notes

## Test plan
- [x] All 55 JS tests pass
- [x] All 33 R tests pass
- [x] Full `quarto render` succeeds (89/89 files)
- [ ] Verify Day 8-9 major activity titles render with correct font styling
- [ ] Verify Day 10-11 download buttons appear and produce .txt files
- [ ] Verify Day 12 activities show as H2 in page outline

Closes #148, closes #149, closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)