### PR TITLE
Add accessible labels to OJS inputs (Days 7-12) + render fix

### DIFF
--- a/content/days/day-07/02-numerical-targets.qmd
+++ b/content/days/day-07/02-numerical-targets.qmd
@@ -38,19 +38,19 @@ Think of a few further examples of the three kinds of numerical targets. With Ca
 Category 1—facts of life:
 
 ```{ojs}
-viewof activity_7a_1 = Inputs.textarea({placeholder: "Type your examples here.", rows: 5})
+viewof activity_7a_1 = Inputs.textarea({label: "Category 1 — facts of life: examples", placeholder: "Type your examples here.", rows: 5})
 ```
 
 Category 2—numbers for guidance and help:
 
 ```{ojs}
-viewof activity_7a_2 = Inputs.textarea({placeholder: "Type your examples here.", rows: 5})
+viewof activity_7a_2 = Inputs.textarea({label: "Category 2 — numbers for guidance and help: examples", placeholder: "Type your examples here.", rows: 5})
 ```
 
 Category 3—numbers for judgment, punishment, reward:
 
 ```{ojs}
-viewof activity_7a_3 = Inputs.textarea({placeholder: "Type your examples here.", rows: 5})
+viewof activity_7a_3 = Inputs.textarea({label: "Category 3 — numbers for judgment, punishment, reward: examples", placeholder: "Type your examples here.", rows: 5})
 ```
 
 <div class="activity_afterthought">(There is a little discussion on Appendix page 31.)</div>
@@ -65,7 +65,7 @@ viewof activity_7a_3 = Inputs.textarea({placeholder: "Type your examples here.",
 Remind yourself (e.g. by looking back at what you've written about Point 11 and the 3rd and 5th Deadly Diseases (on Day 5 pages 10–11, 22–23 and 26–27 respectively)) of some of the reasons why Category 3 is incompatible with the Deming philosophy. Again include specific examples from the true stories on Day 6 and be ready to add more here as you read through today's further true stories on pages 9–18.
 
 ```{ojs}
-viewof activity_7b = Inputs.textarea({placeholder: "Type your comments here.", rows: 15})
+viewof activity_7b = Inputs.textarea({label: "Reasons why Category 3 is incompatible with the Deming philosophy, with specific examples", placeholder: "Type your comments here.", rows: 15})
 ```
 
 </div>

--- a/content/days/day-07/03-performance-indicators.qmd
+++ b/content/days/day-07/03-performance-indicators.qmd
@@ -22,7 +22,7 @@ There are two particular problems.
 Can you think what those two problems might be? You may find a clue in the above introduction.
 
 ```{ojs}
-viewof thought_7c = Inputs.textarea({placeholder: "Type your comments here.", rows: 10})
+viewof thought_7c = Inputs.textarea({label: "What two particular problems with performance indicators can you think of?", placeholder: "Type your comments here.", rows: 10})
 ```
 
 <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_7c" aria-expanded="false" aria-controls="collapse_7c">

--- a/content/days/day-07/04-many-more-true-stories.qmd
+++ b/content/days/day-07/04-many-more-true-stories.qmd
@@ -256,7 +256,7 @@ UK readers may have recognised several parallels between the above account and s
 (b) The space below is left for some brief notes on your own true stories (see the top of page 9).
 
 ```{ojs}
-viewof activity_7d = Inputs.textarea({placeholder: "Type your own true stories here.", rows: 10})
+viewof activity_7d = Inputs.textarea({label: "Brief notes on your own true stories of numerical targets", placeholder: "Type your own true stories here.", rows: 10})
 ```
 
 </div>

--- a/content/days/day-07/05-thirteenth-obstacle.qmd
+++ b/content/days/day-07/05-thirteenth-obstacle.qmd
@@ -44,7 +44,7 @@ Everybody's work is affected to some extent by the conditions under which they a
 **1.** Write down what you would regard as the most comfortable, the "ideal", temperature for your work:
 
 ```{ojs}
-viewof activity_7e_1 = Inputs.text({placeholder: "e.g. 21°C", width: 200})
+viewof activity_7e_1 = Inputs.text({label: "Step 1: Your most comfortable, 'ideal' working temperature", placeholder: "e.g. 21°C", width: 200})
 ```
 
 **2.** Now write down a fairly wide temperature scale around that ideal value (for illustration, I'm using three steps of 5°C either side of 21°):
@@ -52,13 +52,13 @@ viewof activity_7e_1 = Inputs.text({placeholder: "e.g. 21°C", width: 200})
 Thus, e.g., &nbsp;&nbsp;&nbsp; 6°C &nbsp;&nbsp;&nbsp; 11°C &nbsp;&nbsp;&nbsp; 16°C &nbsp;&nbsp;&nbsp; 22°C &nbsp;&nbsp;&nbsp; 26°C &nbsp;&nbsp;&nbsp; 31°C &nbsp;&nbsp;&nbsp; 36°C
 
 ```{ojs}
-viewof activity_7e_2 = Inputs.text({placeholder: "Write your seven temperatures here, e.g. 6°C, 11°C, 16°C, 21°C, 26°C, 31°C, 36°C", width: 600})
+viewof activity_7e_2 = Inputs.text({label: "Step 2: A fairly wide temperature scale around your ideal value (seven temperatures)", placeholder: "Write your seven temperatures here, e.g. 6°C, 11°C, 16°C, 21°C, 26°C, 31°C, 36°C", width: 600})
 ```
 
 **3.** Presumably, whatever work you are doing, you will do it best at your "ideal" temperature. So let's represent that amount and quality of work done at the ideal temperature by 100% in whatever connections you deem relevant: accuracy, amount, creativity, concentration, quality in any appropriate sense. Now think of working at those other temperatures. If it is noticeably hotter or colder than your ideal temperature, your work is very likely to suffer. So, compared with the 100% at the ideal temperature, what would be the approximate percentages representing the amount and goodness of your work at those other six temperatures? Firstly, copy over your seven temperatures from step 2 and then write in your approximate percentages underneath them:
 
 ```{ojs}
-viewof activity_7e_3 = Inputs.textarea({placeholder: "Write your temperatures and percentages here, e.g.\n6°C → 5%\n11°C → 50%\n16°C → 85%\n21°C → 100%\n26°C → 90%\n31°C → 55%\n36°C → 15%", rows: 8})
+viewof activity_7e_3 = Inputs.textarea({label: "Step 3: Approximate percentages of your work quality at each of the seven temperatures", placeholder: "Write your temperatures and percentages here, e.g.\n6°C → 5%\n11°C → 50%\n16°C → 85%\n21°C → 100%\n26°C → 90%\n31°C → 55%\n36°C → 15%", rows: 8})
 ```
 
 Here are my own answers:
@@ -69,7 +69,7 @@ Here are my own answers:
 **4.** Now subtract your percentages from 100%, therefore obtaining the percentage loss in your work through having to suffer a temperature which is too high or too low:
 
 ```{ojs}
-viewof activity_7e_4 = Inputs.textarea({placeholder: "Write your temperatures and percentage losses here, e.g.\n6°C → 95%\n11°C → 50%\n16°C → 15%\n21°C → 0%\n26°C → 10%\n31°C → 45%\n36°C → 85%", rows: 8})
+viewof activity_7e_4 = Inputs.textarea({label: "Step 4: Percentage loss in your work at each temperature (100% minus your Step 3 values)", placeholder: "Write your temperatures and percentage losses here, e.g.\n6°C → 95%\n11°C → 50%\n16°C → 15%\n21°C → 0%\n26°C → 10%\n31°C → 45%\n36°C → 85%", rows: 8})
 ```
 
 Here are my answers:

--- a/content/days/day-07/06-taguchi-reflections.qmd
+++ b/content/days/day-07/06-taguchi-reflections.qmd
@@ -13,7 +13,7 @@ execute:
 What does this shape of the Taguchi loss function (the "parabola") tell you about how the loss varies with temperature (or whatever else is being represented on the horizontal axis)?
 
 ```{ojs}
-viewof thought_7f = Inputs.textarea({placeholder: "Type your comments here.", rows: 10})
+viewof thought_7f = Inputs.textarea({label: "What does the parabola shape of the Taguchi loss function tell you about how loss varies with temperature?", placeholder: "Type your comments here.", rows: 10})
 ```
 
 <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_7f" aria-expanded="false" aria-controls="collapse_7f">
@@ -46,7 +46,7 @@ But, in comparison, let's return to the concept of conformance to specifications
 So, rather than the Taguchi shape, what shape of loss function would justify the use of "conformance to specifications" thinking and behaviour? Remember: *all* values inside the specifications are then treated just the same as if they were exactly at the optimum, whereas *no* value outside the specifications is accepted: that's rejected or illegal, etc *irrespective* of how close it is to the relevant specification limit.
 
 ```{ojs}
-viewof thought_7g = Inputs.textarea({placeholder: "Type your comments here.", rows: 10})
+viewof thought_7g = Inputs.textarea({label: "What shape of loss function would justify 'conformance to specifications' thinking?", placeholder: "Type your comments here.", rows: 10})
 ```
 
 <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_7g" aria-expanded="false" aria-controls="collapse_7g">
@@ -83,7 +83,7 @@ What do those two loss functions apparently tell you about:
 &nbsp;&nbsp;&nbsp;&nbsp; *Conformance to specifications loss function:*
 
 ```{ojs}
-viewof thought_7h = Inputs.textarea({placeholder: "Type your comments here.", rows: 10})
+viewof thought_7h = Inputs.textarea({label: "What do the two loss functions tell you about (1) the need for continual improvement and (2) keeping a process properly centred?", placeholder: "Type your comments here.", rows: 10})
 ```
 
 <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_7h" aria-expanded="false" aria-controls="collapse_7h">

--- a/content/days/day-07/07-major-activity.qmd
+++ b/content/days/day-07/07-major-activity.qmd
@@ -33,25 +33,25 @@ Please begin by reading through page 27 again.
 **1. [Hope for instant pudding.]{style="color: blue"}** (*Out of the Crisis* pages 107–108[126–127]; Appendix page 32.) The ever-lasting search for the "quick fix"! The term "instant pudding" relates to certain kinds of what are known as "convenience foods": buy a packet, stir in some water, heat, and serve! Expensive and not very nutritious.
 
 ```{ojs}
-viewof activity_7i_1 = Inputs.textarea({placeholder: "Your notes on Obstacle 1.", rows: 5})
+viewof activity_7i_1 = Inputs.textarea({label: "Obstacle 1: Hope for instant pudding — your notes", placeholder: "Your notes on Obstacle 1.", rows: 5})
 ```
 
 **2. [The supposition that solving problems, automation, gadgets, and new machinery will transform industry.]{style="color: blue"}** (*Out of the Crisis* page 108 [pages 127–128]; Appendix page 32.) Firstly, solving problems only puts right what should not have been wrong. For the other items mentioned here, the point is that you cannot "buy" transformation. At the beginning of *The New Economics* Chapter 4, Dr Deming emphasises that ["The first step is transformation of the individual"]{.deming_quote} who then "will perceive new meaning to his life, to events, to numbers, to interactions between people". Again, you cannot "buy" that.
 
 ```{ojs}
-viewof activity_7i_2 = Inputs.textarea({placeholder: "Your notes on Obstacle 2.", rows: 5})
+viewof activity_7i_2 = Inputs.textarea({label: "Obstacle 2: The supposition that solving problems, automation, gadgets, and new machinery will transform industry — your notes", placeholder: "Your notes on Obstacle 2.", rows: 5})
 ```
 
 **3. [Search for examples.]{style="color: blue"}** (*Out of the Crisis* pages 109–110[128–128]; Appendix pages 32–33.) A large topic, the subject of *DemDim* Chapter 16. Also see Paragraph 7 (pages 275–276) in the Theory of Knowledge section of *DemDim* Chapter 18. One trouble is that you can usually find numerous examples to support just about any idea, whether that idea be good or bad. Mindless copying of examples is therefore—well—mindless! Dr Deming similarly warns against simply relying on experience. You have seen something of this on Day 6 pages 1–2; you will see more on Day 11.
 
 ```{ojs}
-viewof activity_7i_3 = Inputs.textarea({placeholder: "Your notes on Obstacle 3.", rows: 5})
+viewof activity_7i_3 = Inputs.textarea({label: "Obstacle 3: Search for examples — your notes", placeholder: "Your notes on Obstacle 3.", rows: 5})
 ```
 
 **4. ["Our problems are different."]{style="color: blue"}** (*Out of the Crisis* page 110[130]; Appendix page 33.) This is one of the most common excuses by managers who do not want to learn and do not want to change.
 
 ```{ojs}
-viewof activity_7i_4 = Inputs.textarea({placeholder: "Your notes on Obstacle 4.", rows: 5})
+viewof activity_7i_4 = Inputs.textarea({label: "Obstacle 4: 'Our problems are different' — your notes", placeholder: "Your notes on Obstacle 4.", rows: 5})
 ```
 
 **5. [Obsolescence in Schools [i.e. Schools of Business].]{style="color: blue"}** (*Out of the Crisis* pages 110–111[130–131]; Appendix page 33.) On *Out of the Crisis* page 110[130], Deming quotes Robert Reich in a private communication as follows: "As profits declined, generally, from 1970 onward, many American companies attempted to bolster their earnings by acquisition and paper profits. The people in finance and law became the important people in the company. Quality and competitive position were submerged. Schools of Business responded to populate demand for finance and creative accounting. The results are decline."
@@ -59,73 +59,73 @@ viewof activity_7i_4 = Inputs.textarea({placeholder: "Your notes on Obstacle 4."
 Robert Reich, who was Secretary of Labour in Bill Clinton's administration, is featured in conversation with Dr Deming in the first two of the Deming Library videos: *The New Economic Age* and *The 14 Points*.
 
 ```{ojs}
-viewof activity_7i_5 = Inputs.textarea({placeholder: "Your notes on Obstacle 5.", rows: 5})
+viewof activity_7i_5 = Inputs.textarea({label: "Obstacle 5: Obsolescence in Schools (of Business) — your notes", placeholder: "Your notes on Obstacle 5.", rows: 5})
 ```
 
 **6. [Poor teaching of statistical methods in industry.]{style="color: blue"}** (*Out of the Crisis* pages 111–113[131–133]; Appendix pages 33–34.) A basic problem here is that the large majority of "conventional" statistics teaching is to do with matters such as probabilities, distributions, sampling from "populations", and the like. The subject is essentially treated as a branch of Mathematics, dependent on mathematical models. But the real world is primarily concerned with ever-changing processes that therefore do not fit neat mathematical models. Quite unlike most statistical tools, the control chart, as understood, taught and used by Drs Shewhart and Deming, is not dependent on mathematical models: it is designed for the real world. Because of not understanding this fact and its importance, many teachers try to force the control chart into the conventional mathematical mould—thus destroying its unique virtue! This is all touched upon in the Overture, in my discussion on Pause for Thought 2–b on Appendix page 7, and in the Springboard article cited on Day 1 page 8. There is also much more in the Optional Extras section.
 
 ```{ojs}
-viewof activity_7i_6 = Inputs.textarea({placeholder: "Your notes on Obstacle 6.", rows: 5})
+viewof activity_7i_6 = Inputs.textarea({label: "Obstacle 6: Poor teaching of statistical methods in industry — your notes", placeholder: "Your notes on Obstacle 6.", rows: 5})
 ```
 
 **7. [Use of [Military Standard 105D and other] tables for acceptance.]{style="color: blue"}** (*Out of the Crisis* page 113[133]; Appendix page 34.) This alludes to old-fashioned "acceptance sampling" schemes where batches are sampled and then accepted or rejected according to the number of defective items found in the sample. What's wrong with that? Well, for a start, an essential requirement for deciding on the details of such a plan is the specification of an acceptable proportion of defectives! And, having mentioned that word "specification", how is a "defective" defined?—which brings us back to some of the problems with "conformance to specifications" and also takes us forward to operational definitions on Day 11. There is much more in *Out of the Crisis* Chapter 15.
 
 ```{ojs}
-viewof activity_7i_7 = Inputs.textarea({placeholder: "Your notes on Obstacle 7.", rows: 5})
+viewof activity_7i_7 = Inputs.textarea({label: "Obstacle 7: Use of Military Standard 105D and other tables for acceptance — your notes", placeholder: "Your notes on Obstacle 7.", rows: 5})
 ```
 
 **8. ["Our Quality Control Department takes care of all our problems of quality."]{style="color: blue"}** (*Out of the Crisis* pages 113–114[133–134]; Appendix page 34.) Substantially, this takes us back to the delusion that quality can be obtained by inspection (c.f. the third of the 14 Points on Day 4 pages 20–21) or by "quality assurance".
 
 ```{ojs}
-viewof activity_7i_8 = Inputs.textarea({placeholder: "Your notes on Obstacle 8.", rows: 5})
+viewof activity_7i_8 = Inputs.textarea({label: "Obstacle 8: 'Our Quality Control Department takes care of all our problems of quality' — your notes", placeholder: "Your notes on Obstacle 8.", rows: 5})
 ```
 
 **9. ["Our troubles lie entirely in the workforce."]{style="color: blue"}** (*Out of the Crisis* pages 114–115[134–135]; Appendix pages 34–35.) Same comment as with Obstacle 4 (page 29). This nonsense is, of course, entirely contradictory to all we have learned about most of the problems (85%, 94%, 98%?) lying in the system (common causes).
 
 ```{ojs}
-viewof activity_7i_9 = Inputs.textarea({placeholder: "Your notes on Obstacle 9.", rows: 5})
+viewof activity_7i_9 = Inputs.textarea({label: "Obstacle 9: 'Our troubles lie entirely in the workforce' — your notes", placeholder: "Your notes on Obstacle 9.", rows: 5})
 ```
 
 **10. [False starts.]{style="color: blue"}** (*Out of the Crisis* pages 115–117[135–138]; Appendix page 35.) Just think back over the years in your organisation. How many great new initiatives, flavours of the month, the latest panacea, have been tried? Where are they now?
 
 ```{ojs}
-viewof activity_7i_10 = Inputs.textarea({placeholder: "Your notes on Obstacle 10.", rows: 5})
+viewof activity_7i_10 = Inputs.textarea({label: "Obstacle 10: False starts — your notes", placeholder: "Your notes on Obstacle 10.", rows: 5})
 ```
 
 **11. ["We installed quality control."]{style="color: blue"}** (*Out of the Crisis* page 117 [pages 138–139]; Appendix page 35.) As with Obstacle 2, quality cannot be "bought"; see my comments on that Obstacle (page 28). Any management that thinks it can "install quality control" will achieve neither quality nor control.
 
 ```{ojs}
-viewof activity_7i_11 = Inputs.textarea({placeholder: "Your notes on Obstacle 11.", rows: 5})
+viewof activity_7i_11 = Inputs.textarea({label: "Obstacle 11: 'We installed quality control' — your notes", placeholder: "Your notes on Obstacle 11.", rows: 5})
 ```
 
 **12. [The unmanned computer.]{style="color: blue"}** (*Out of the Crisis* page 118[139]; Appendix page 35.) With the great changes in computer technology since the mid-1980s when *Out of the Crisis* was published, the nature of this Obstacle has changed—but it is still an Obstacle! The complaint then was that computers would mostly produce "reams of figures" which were difficult to analyse. Nowadays one can produce a proliferation of multi-coloured multi-dimensional graphs at the touch of a key—which are also often difficult to analyse! See the superb fifth chapter: "Graphical Purgatory" in Don Wheeler's *Making Sense of Data*.
 
 ```{ojs}
-viewof activity_7i_12 = Inputs.textarea({placeholder: "Your notes on Obstacle 12.", rows: 5})
+viewof activity_7i_12 = Inputs.textarea({label: "Obstacle 12: The unmanned computer — your notes", placeholder: "Your notes on Obstacle 12.", rows: 5})
 ```
 
 **13. [The supposition that it is only necessary to meet specifications.]{style="color: blue"}** (*Out of the Crisis* pages 118–119[139–141]; Appendix page 36.) After your work with the Taguchi loss function, I think I need add nothing here! And you are now so familiar with this matter that I suggest you soon move on to the remaining three Obstacles.
 
 ```{ojs}
-viewof activity_7i_13 = Inputs.textarea({placeholder: "Your notes on Obstacle 13.", rows: 5})
+viewof activity_7i_13 = Inputs.textarea({label: "Obstacle 13: The supposition that it is only necessary to meet specifications — your notes", placeholder: "Your notes on Obstacle 13.", rows: 5})
 ```
 
 **14. [The fallacy of zero defects.]{style="color: blue"}** (*Out of the Crisis* pages 119–120[141–142]; Appendix page 36.) With "defect" = "outside specifications", this is equivalent to Obstacle 13 above. In addition, Dr Deming saw zero-defects policies as often inviting tampering, suffering effects we have seen in the Funnel Experiment. Recall also Mack's mention of Zero Defects (Day 6 page 11).
 
 ```{ojs}
-viewof activity_7i_14 = Inputs.textarea({placeholder: "Your notes on Obstacle 14.", rows: 5})
+viewof activity_7i_14 = Inputs.textarea({label: "Obstacle 14: The fallacy of zero defects — your notes", placeholder: "Your notes on Obstacle 14.", rows: 5})
 ```
 
 **15. [Inadequate testing of prototypes.]{style="color: blue"}** (*Out of the Crisis* pages 120–121[142–143]; Appendix pages 36–37.) Prototypes are usually tested in "laboratory-controlled conditions"—which are likely to be substantially different from the very variable conditions to be experienced in use.
 
 ```{ojs}
-viewof activity_7i_15 = Inputs.textarea({placeholder: "Your notes on Obstacle 15.", rows: 5})
+viewof activity_7i_15 = Inputs.textarea({label: "Obstacle 15: Inadequate testing of prototypes — your notes", placeholder: "Your notes on Obstacle 15.", rows: 5})
 ```
 
 **16. ["Anyone that comes to try to help us must understand all about our business."]{style="color: blue"}** (*Out of the Crisis* page 121[143]; Appendix page 37.) Strongly linked with Obstacle 4 (page 29) and my comment there. We have already pointed out on Day 6 page 6 that Dr Deming referred to Profound Knowledge as ["outside knowledge"]{.deming_quote}; another pertinent quote (e.g. on *The New Economics* page 39[54]) is ["A system can not understand itself."]{.deming_quote} Real help comes from *new* knowledge.
 
 ```{ojs}
-viewof activity_7i_16 = Inputs.textarea({placeholder: "Your notes on Obstacle 16.", rows: 5})
+viewof activity_7i_16 = Inputs.textarea({label: "Obstacle 16: 'Anyone that comes to try to help us must understand all about our business' — your notes", placeholder: "Your notes on Obstacle 16.", rows: 5})
 ```
 
 </div>

--- a/content/days/day-08/02-joy-in-work.qmd
+++ b/content/days/day-08/02-joy-in-work.qmd
@@ -14,31 +14,31 @@ So now please **read *DemDim* Chapter 13 (pages 197–202): "Joy in Work"**.
 Is there much Joy in Work in your organisation—either on your part or anybody else's?
 
 ```{ojs}
-viewof activity_8a_1 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8a_1 = Inputs.textarea({label: "Is there much Joy in Work in your organisation — either on your part or anybody else's?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of things in your organisation prevent, or at least obstruct, Joy in Work?
 
 ```{ojs}
-viewof activity_8a_2 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8a_2 = Inputs.textarea({label: "What kind of things in your organisation prevent, or at least obstruct, Joy in Work?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What harm does lack of Joy in Work do to your organisation?
 
 ```{ojs}
-viewof activity_8a_3 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8a_3 = Inputs.textarea({label: "What harm does lack of Joy in Work do to your organisation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of things could be done in your organisation to encourage and enable more Joy in Work?
 
 ```{ojs}
-viewof activity_8a_4 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8a_4 = Inputs.textarea({label: "What kind of things could be done in your organisation to encourage and enable more Joy in Work?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of benefits to your organisation could result if there were to be more Joy in Work?
 
 ```{ojs}
-viewof activity_8a_5 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8a_5 = Inputs.textarea({label: "What kind of benefits to your organisation could result if there were to be more Joy in Work?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 </div>

--- a/content/days/day-08/03-innovation.qmd
+++ b/content/days/day-08/03-innovation.qmd
@@ -14,31 +14,31 @@ Next please **read *DemDim* Chapter 14 (pages 203–212): "Innovation—not just
 Is there much innovation in your organisation—either on your part or anybody else's?
 
 ```{ojs}
-viewof activity_8b_1 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8b_1 = Inputs.textarea({label: "Is there much innovation in your organisation — either on your part or anybody else's?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of things in your organisation prevent, or at least obstruct, innovation?
 
 ```{ojs}
-viewof activity_8b_2 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8b_2 = Inputs.textarea({label: "What kind of things in your organisation prevent, or at least obstruct, innovation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What harm does lack of innovation do to your organisation?
 
 ```{ojs}
-viewof activity_8b_3 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8b_3 = Inputs.textarea({label: "What harm does lack of innovation do to your organisation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of things could be done in your organisation to encourage and enable more innovation?
 
 ```{ojs}
-viewof activity_8b_4 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8b_4 = Inputs.textarea({label: "What kind of things could be done in your organisation to encourage and enable more innovation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of benefits to your organisation could result if there were to be more innovation?
 
 ```{ojs}
-viewof activity_8b_5 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8b_5 = Inputs.textarea({label: "What kind of benefits to your organisation could result if there were to be more innovation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 </div>

--- a/content/days/day-08/04-cooperation.qmd
+++ b/content/days/day-08/04-cooperation.qmd
@@ -14,31 +14,31 @@ Now please **read pages 213–231 of *DemDim* Chapter 15: "Cooperation: Win-Win�
 Is there much cooperation in your organisation—either on your part or anybody else's?
 
 ```{ojs}
-viewof activity_8c_1 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8c_1 = Inputs.textarea({label: "Is there much cooperation in your organisation — either on your part or anybody else's?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of things in your organisation prevent, or at least obstruct, cooperation?
 
 ```{ojs}
-viewof activity_8c_2 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8c_2 = Inputs.textarea({label: "What kind of things in your organisation prevent, or at least obstruct, cooperation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What harm does lack of cooperation do to your organisation?
 
 ```{ojs}
-viewof activity_8c_3 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8c_3 = Inputs.textarea({label: "What harm does lack of cooperation do to your organisation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of things could be done in your organisation to encourage and enable more cooperation?
 
 ```{ojs}
-viewof activity_8c_4 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8c_4 = Inputs.textarea({label: "What kind of things could be done in your organisation to encourage and enable more cooperation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 What kind of benefits to your organisation could result if there were to be more cooperation?
 
 ```{ojs}
-viewof activity_8c_5 = Inputs.textarea({placeholder: "Type your comments here.", rows: 8})
+viewof activity_8c_5 = Inputs.textarea({label: "What kind of benefits to your organisation could result if there were to be more cooperation?", placeholder: "Type your comments here.", rows: 8})
 ```
 
 </div>

--- a/content/days/day-09/02-a-system.qmd
+++ b/content/days/day-09/02-a-system.qmd
@@ -59,7 +59,7 @@ Were there a prize for the best-ever combination of simple and profound, this wo
 So what is the important difference between the "Old Way" and the "New Way"?
 
 ```{ojs}
-viewof thought_9a = Inputs.textarea({placeholder: "Type your comments here.", rows: 10})
+viewof thought_9a = Inputs.textarea({label: "What is the important difference between the 'Old Way' and the 'New Way'?", placeholder: "Type your comments here.", rows: 10})
 ```
 
 <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_9a" aria-expanded="false" aria-controls="collapse_9a">
@@ -80,7 +80,7 @@ It's simply the difference between a line and a circle! The line stops (or disap
 What kind of things does that simple change from a line to a circle signify to you?
 
 ```{ojs}
-viewof thought_9b = Inputs.textarea({placeholder: "Type your comments here.", rows: 10})
+viewof thought_9b = Inputs.textarea({label: "What does that simple change from a line to a circle signify to you?", placeholder: "Type your comments here.", rows: 10})
 ```
 
 <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_9b" aria-expanded="false" aria-controls="collapse_9b">

--- a/content/days/day-09/03-activity-9c-and-organisation-charts.qmd
+++ b/content/days/day-09/03-activity-9c-and-organisation-charts.qmd
@@ -12,7 +12,7 @@ execute:
 With regard to your organisation, suggest some ways in which the improvement of quality would reduce cost.
 
 ```{ojs}
-viewof activity_9c = Inputs.textarea({placeholder: "Type your suggestions here.", rows: 10})
+viewof activity_9c = Inputs.textarea({label: "Suggest some ways in which the improvement of quality would reduce cost in your organisation", placeholder: "Type your suggestions here.", rows: 10})
 ```
 
 [If you need a hint, you will find one on Appendix page 38.]
@@ -52,7 +52,7 @@ If you would like to study more on this, I strongly recommend Chapter 1 of *The 
 How would you describe the relationship between Shewhart's diagram of the "New Way" (refer back to the diagram on page 3 and also to your thoughts on page 4) with Deming's "Production (or Organisation) Viewed as a System" flow diagram on page 2? And what might that tell you about the *purpose* of Deming's flow diagram?
 
 ```{ojs}
-viewof thought_9d = Inputs.textarea({placeholder: "Type your comments here.", rows: 10})
+viewof thought_9d = Inputs.textarea({label: "How would you describe the relationship between Shewhart's 'New Way' diagram and Deming's flow diagram, and what does that tell you about the purpose of Deming's flow diagram?", placeholder: "Type your comments here.", rows: 10})
 ```
 
 <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_9d" aria-expanded="false" aria-controls="collapse_9d">

--- a/content/days/day-09/04-major-activity.qmd
+++ b/content/days/day-09/04-major-activity.qmd
@@ -20,13 +20,13 @@ The procedure in this Major Activity is divided into five stages. The first stag
 **Stage 1.** Therefore first spend a little time beginning to try to construct a system of medical care in the space below, of similar layout to Dr Deming's famous flow diagram and repeatedly referring back to it on page 2 or *DemDim* page 133. But remember to keep it "macro": do not try to make it detailed or complicated---be guided by the nature of what is in his diagram. Also, don't expect to complete this task right now, as there is some help for you in the Appendix. However, as usual, do what you can first before turning to the Appendix, for that is Stage 2 below. Then at Stage 3 I shall give you some suggestions about how to tackle the flow diagram of your organisation. You might like to look ahead at those thoughts in Stage 3 right now (on the next page) and then also use them to help you with this initial practice diagram.
 
 ```{ojs}
-viewof stage1 = Inputs.textarea({placeholder: "Sketch out your system of medical care here. Think about the major components and how they connect.", rows: 15})
+viewof stage1 = Inputs.textarea({label: "Stage 1: Sketch a 'macro' flow diagram of a system of medical care", placeholder: "Sketch out your system of medical care here. Think about the major components and how they connect.", rows: 15})
 ```
 
 **Stage 2.** Now study my attempt on Appendix page 38. That may give you some further ideas as to what you might include in your attempt at Stage 1. So then spend a little more time revising your Stage 1 diagram.
 
 ```{ojs}
-viewof stage2 = Inputs.textarea({placeholder: "Revise your Stage 1 diagram here after studying the Appendix.", rows: 15})
+viewof stage2 = Inputs.textarea({label: "Stage 2: Revise your Stage 1 diagram after studying the Appendix", placeholder: "Revise your Stage 1 diagram here after studying the Appendix.", rows: 15})
 ```
 
 **Stage 3.** And now try to apply what you have learned during the first two stages to develop an "Organisation Viewed as a System" flow diagram of your own organisation.
@@ -34,19 +34,19 @@ viewof stage2 = Inputs.textarea({placeholder: "Revise your Stage 1 diagram here 
 It would probably be sensible to start with the central track, broadly summarising the main aspects of what the organisation does. In Deming's diagram the central track starts at "Receipt and test of materials", then proceeds through production, assembly and inspection, and goes as far as "Distribution". A useful way to then proceed with the rest of the diagram is to ask yourself lots of questions. What comes into the system? Where does it come from? What important contributions enter the central track "from the side" (like the "Tests of processes, machines, methods, costs" in Deming's diagram)? What goes out of our system? To where, to whom? That is, who and where are our "consumers"? How do we get to learn what our consumers think about what they get from us? What do we do with that information? How do we use it to help improve the system?
 
 ```{ojs}
-viewof stage3 = Inputs.textarea({placeholder: "Develop an 'Organisation Viewed as a System' flow diagram for your own organisation.", rows: 15})
+viewof stage3 = Inputs.textarea({label: "Stage 3: Develop an 'Organisation Viewed as a System' flow diagram for your own organisation", placeholder: "Develop an 'Organisation Viewed as a System' flow diagram for your own organisation.", rows: 15})
 ```
 
 **Stage 4.** Next, considering your flow diagram constructed at Stage 3, describe examples of how what happens in one part of the flow diagram is being hindered by some things happening (or not happening) elsewhere in the flow diagram. Does consideration of the *conventional* organisation chart explain why those harmful things are happening? What could be done to *help* rather than *hinder*?
 
 ```{ojs}
-viewof stage4 = Inputs.textarea({placeholder: "Describe examples of how parts of your flow diagram are being hindered by things happening elsewhere.", rows: 15})
+viewof stage4 = Inputs.textarea({label: "Stage 4: Describe examples of how parts of your flow diagram are hindered by things happening elsewhere", placeholder: "Describe examples of how parts of your flow diagram are being hindered by things happening elsewhere.", rows: 15})
 ```
 
 **Stage 5.** Finally construct a modified version of your Stage 3 diagram, bearing in mind your answers at Stage 4, thus showing how your organisation could become a *better* system than it is now.
 
 ```{ojs}
-viewof stage5 = Inputs.textarea({placeholder: "Construct a modified version showing how your organisation could become a better system.", rows: 15})
+viewof stage5 = Inputs.textarea({label: "Stage 5: Construct a modified version showing how your organisation could become a better system", placeholder: "Construct a modified version showing how your organisation could become a better system.", rows: 15})
 ```
 
 <div class="separator">

--- a/content/days/day-10/02-appreciation-for-a-system.qmd
+++ b/content/days/day-10/02-appreciation-for-a-system.qmd
@@ -57,7 +57,7 @@ The components need not all be clearly defined and documented: people may merely
 </div>
 
 ```{ojs}
-viewof note_10_components = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_components = Inputs.textarea({label: "Your notes on the system's components and management's role", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -77,7 +77,7 @@ The aim proposed here for any organisation is for everybody to gain---stockholde
 </div>
 
 ```{ojs}
-viewof note_10_aim = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_aim = Inputs.textarea({label: "Your notes on 'the aim of the system' (everybody to gain)", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 #### 2. Optimisation of a system
@@ -99,7 +99,7 @@ Growth in size and complexity of a system, and rapid changes with time, may requ
 </div>
 
 ```{ojs}
-viewof note_10_optimisation = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_optimisation = Inputs.textarea({label: "Your notes on optimisation, suboptimisation, and the boundary of the system", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -119,7 +119,7 @@ A flow diagram [*remember what he means by this term: the famous diagram on Day 
 </div>
 
 ```{ojs}
-viewof note_10_aide_flowdiagram = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_aide_flowdiagram = Inputs.textarea({label: "Your notes on guidance from outside, the 'aide to the president', and the flow diagram", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -141,7 +141,7 @@ A business is not merely an organisation chart [*of the conventional kind*], all
 </div>
 
 ```{ojs}
-viewof note_10_orchestra_business = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_orchestra_business = Inputs.textarea({label: "Your notes on the orchestra example and a business as a network", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -153,7 +153,7 @@ The performance of any component is to be judged in terms of its contribution to
 </div>
 
 ```{ojs}
-viewof note_10_schools_performance = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_schools_performance = Inputs.textarea({label: "Your notes on the system of schools and judging a component's performance", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -165,7 +165,7 @@ It would be poor management to save money on travelling expenses without regard 
 </div>
 
 ```{ojs}
-viewof note_10_poor_management = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_poor_management = Inputs.textarea({label: "Your notes on the examples of poor management (lowest price, travel costs, etc.)", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -177,7 +177,7 @@ Optimisation of a system should be the basis for negotiation between any two peo
 </div>
 
 ```{ojs}
-viewof note_10_winlose = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_winlose = Inputs.textarea({label: "Your notes on Win–Lose structures and optimisation as the basis for negotiation", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -205,7 +205,7 @@ There is, of course, no need to include in your comments the technical details o
 </div>
 
 ```{ojs}
-viewof note_10_suboptimisation_taguchi = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_suboptimisation_taguchi = Inputs.textarea({label: "Your notes on examples of suboptimisation and the relevance of the Taguchi loss function", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 That completes the items which Dr Deming included for Part A in his May 1990 version of the System of Profound Knowledge. There were rather more of them than for any of the other three parts. As mentioned earlier, that is why the relevant Activity (concerning links between Part A and the 14 Points and Deadly Diseases) is postponed to the beginning of this afternoon rather than being crammed into this morning. In all other cases, the similar Activity will conclude the relevant half-day.
@@ -215,7 +215,7 @@ That completes the items which Dr Deming included for Part A in his May 1990 ver
 Now read through *DemDim* pages 264–270, revising your earlier comments and adding any new points below.
 
 ```{ojs}
-viewof note_10_demdim_parta = Inputs.textarea({placeholder: "Additional notes from DemDim pages 264–270.", rows: 6})
+viewof note_10_demdim_parta = Inputs.textarea({label: "Additional notes after reading DemDim pages 264–270 on Appreciation for a System", placeholder: "Additional notes from DemDim pages 264–270.", rows: 6})
 ```
 
 <div class="neave_note">

--- a/content/days/day-10/03-activity-10a.qmd
+++ b/content/days/day-10/03-activity-10a.qmd
@@ -22,133 +22,133 @@ As mentioned on Day 9 page 27, in each case please put a number on a 0--5 scale 
 
 ```{ojs}
 viewof activity_10a_point1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point1 = Inputs.textarea({label: "Comments — Point 1: Create constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 2.** [Adopt the new philosophy. We are in a new economic age, created in Japan.]{.deming_quote} *(Day 4 pages 18--19.)*
 
 ```{ojs}
 viewof activity_10a_point2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point2 = Inputs.textarea({label: "Comments — Point 2: Adopt the new philosophy", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 3.** [Eliminate the need for mass inspection as a way to achieve quality.]{.deming_quote} *(Day 4 pages 20--21.)*
 
 ```{ojs}
 viewof activity_10a_point3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point3 = Inputs.textarea({label: "Comments — Point 3: Eliminate the need for mass inspection", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 4.** [End the practice of awarding business solely on the basis of price tag.]{.deming_quote} *(Day 4 pages 22--23.)*
 
 ```{ojs}
 viewof activity_10a_point4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point4 = Inputs.textarea({label: "Comments — Point 4: End the practice of awarding business on price tag alone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 5.** [Improve constantly and for ever the system.]{.deming_quote} *(Day 4 pages 24--25.)*
 
 ```{ojs}
 viewof activity_10a_point5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point5 = Inputs.textarea({label: "Comments — Point 5: Improve constantly and forever the system", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 6.** [Institute modern methods of training.]{.deming_quote} *(Day 4 pages 26--27.)*
 
 ```{ojs}
 viewof activity_10a_point6_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point6 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point6 = Inputs.textarea({label: "Comments — Point 6: Institute modern methods of training", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 7.** [Adopt and institute leadership aimed at helping people to do a better job.]{.deming_quote} *(Day 5 pages 2--3.)*
 
 ```{ojs}
 viewof activity_10a_point7_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point7 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point7 = Inputs.textarea({label: "Comments — Point 7: Adopt and institute leadership", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 8.** [Encourage effective two-way communication and other means to drive out fear throughout the organisation.]{.deming_quote} *(Day 5 pages 4--5.)*
 
 ```{ojs}
 viewof activity_10a_point8_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point8 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point8 = Inputs.textarea({label: "Comments — Point 8: Drive out fear", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 9.** [Break down barriers between departments and staff areas.]{.deming_quote} *(Day 5 pages 6--7.)*
 
 ```{ojs}
 viewof activity_10a_point9_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point9 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point9 = Inputs.textarea({label: "Comments — Point 9: Break down barriers between departments and staff areas", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 10.** [Eliminate the use of slogans, posters, and exhortations.]{.deming_quote} *(Day 5 pages 8--9.)*
 
 ```{ojs}
 viewof activity_10a_point10_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point10 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point10 = Inputs.textarea({label: "Comments — Point 10: Eliminate slogans, posters, and exhortations", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 11.** [Eliminate work standards that prescribe quotas for the workforce and numerical goals for people in management.]{.deming_quote} *(Day 5 pages 10--11.)*
 
 ```{ojs}
 viewof activity_10a_point11_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point11 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point11 = Inputs.textarea({label: "Comments — Point 11: Eliminate work standards and numerical goals", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 12.** [Remove the barriers that rob hourly workers, and people in management, of their right to pride of workmanship.]{.deming_quote} *(Day 5 pages 12--13.)*
 
 ```{ojs}
 viewof activity_10a_point12_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point12 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point12 = Inputs.textarea({label: "Comments — Point 12: Remove barriers to pride of workmanship", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 13.** [Institute a vigorous programme of education, and encourage self-improvement for everyone.]{.deming_quote} *(Day 5 pages 14--15.)*
 
 ```{ojs}
 viewof activity_10a_point13_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point13 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point13 = Inputs.textarea({label: "Comments — Point 13: Institute education and self-improvement for everyone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 14.** [Clearly define top management's permanent commitment to ever-improving quality and productivity.]{.deming_quote} *(Day 5 pages 16--17.)*
 
 ```{ojs}
 viewof activity_10a_point14_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_point14 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_point14 = Inputs.textarea({label: "Comments — Point 14: Top management's permanent commitment to ever-improving quality", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 1.** [The crippling disease is lack of constancy of purpose.]{.deming_quote} *(Day 5 pages 18--19.)*
 
 ```{ojs}
 viewof activity_10a_disease1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_disease1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_disease1 = Inputs.textarea({label: "Comments — Disease 1: Lack of constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 2.** [Short-term thinking defeats constancy of purpose.]{.deming_quote} *(Day 5 pages 20--21.)*
 
 ```{ojs}
 viewof activity_10a_disease2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_disease2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_disease2 = Inputs.textarea({label: "Comments — Disease 2: Short-term thinking", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 3.** [The effects of performance appraisal are devastating.]{.deming_quote} *(Day 5 pages 22--23.)*
 
 ```{ojs}
 viewof activity_10a_disease3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_disease3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_disease3 = Inputs.textarea({label: "Comments — Disease 3: The devastating effects of performance appraisal", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 4.** [Mobility of management causes instability.]{.deming_quote} *(Day 5 pages 24--25.)*
 
 ```{ojs}
 viewof activity_10a_disease4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_disease4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_disease4 = Inputs.textarea({label: "Comments — Disease 4: Mobility of management causes instability", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 5.** [One cannot be successful on visible figures alone.]{.deming_quote} *(Day 5 pages 26--27.)*
 
 ```{ojs}
 viewof activity_10a_disease5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10a_disease5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10a_disease5 = Inputs.textarea({label: "Comments — Disease 5: Running on visible figures alone", placeholder: "Your comments.", rows: 3})
 ```
 
 </div>

--- a/content/days/day-10/04-theory-of-variation.qmd
+++ b/content/days/day-10/04-theory-of-variation.qmd
@@ -51,7 +51,7 @@ So we can never *eliminate* variation in what our processes produce. We can and 
 </div>
 
 ```{ojs}
-viewof note_10_variation_12 = Inputs.textarea({placeholder: "Your notes on these items.", rows: 4})
+viewof note_10_variation_12 = Inputs.textarea({label: "Your notes on items 1–2: understanding variation, special and common causes", placeholder: "Your notes on these items.", rows: 4})
 ```
 
 (So, again, it's now over to you for reactions, comments, etc throughout Part B. Keep an eye on Step 2 in the guidance which was summarised on Day 9 page 29.)
@@ -69,7 +69,7 @@ viewof note_10_variation_12 = Inputs.textarea({placeholder: "Your notes on these
 </div>
 
 ```{ojs}
-viewof note_10_capability_leadership = Inputs.textarea({placeholder: "Your notes on these items.", rows: 4})
+viewof note_10_capability_leadership = Inputs.textarea({label: "Your notes on items 3–4: process capability and leadership in stable vs unstable states", placeholder: "Your notes on these items.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -93,7 +93,7 @@ viewof note_10_capability_leadership = Inputs.textarea({placeholder: "Your notes
 </div>
 
 ```{ojs}
-viewof note_10_measurement_mistakes = Inputs.textarea({placeholder: "Your notes on these items.", rows: 4})
+viewof note_10_measurement_mistakes = Inputs.textarea({label: "Your notes on items 5–6: sources of uncertainty and the two kinds of mistakes (tampering)", placeholder: "Your notes on these items.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -109,7 +109,7 @@ viewof note_10_measurement_mistakes = Inputs.textarea({placeholder: "Your notes 
 </div>
 
 ```{ojs}
-viewof note_10_shewhart_interaction = Inputs.textarea({placeholder: "Your notes on these items.", rows: 4})
+viewof note_10_shewhart_interaction = Inputs.textarea({label: "Your notes on items 7–8: Shewhart control charts and interaction of forces", placeholder: "Your notes on these items.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -129,7 +129,7 @@ viewof note_10_shewhart_interaction = Inputs.textarea({placeholder: "Your notes 
 </div>
 
 ```{ojs}
-viewof note_10_enumerative_analytic = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_10_enumerative_analytic = Inputs.textarea({label: "Your notes on item 9: distinction between enumerative studies and analytic problems", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -147,7 +147,7 @@ Examples [*all of Rule 4 of the Funnel*]:
 </div>
 
 ```{ojs}
-viewof note_10_loss_random = Inputs.textarea({placeholder: "Your notes on these items.", rows: 4})
+viewof note_10_loss_random = Inputs.textarea({label: "Your notes on items 10–11: loss functions and losses from random forces (Funnel Rule 4)", placeholder: "Your notes on these items.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -169,7 +169,7 @@ Corollaries of this theorem are frightening.
 </div>
 
 ```{ojs}
-viewof note_10_committee_outside = Inputs.textarea({placeholder: "Your notes on these items.", rows: 4})
+viewof note_10_committee_outside = Inputs.textarea({label: "Your notes on items 12–13: committee enlargement and Profound Knowledge from outside", placeholder: "Your notes on these items.", rows: 4})
 ```
 
 ### Step 3: *DemDim* version
@@ -177,7 +177,7 @@ viewof note_10_committee_outside = Inputs.textarea({placeholder: "Your notes on 
 Now read through *DemDim* pages 270–274, revising your earlier comments and adding new points below.
 
 ```{ojs}
-viewof note_10_demdim_partb = Inputs.textarea({placeholder: "Additional notes from DemDim pages 270–274.", rows: 6})
+viewof note_10_demdim_partb = Inputs.textarea({label: "Additional notes after reading DemDim pages 270–274 on Theory of Variation", placeholder: "Additional notes from DemDim pages 270–274.", rows: 6})
 ```
 
 <div class="neave_note">

--- a/content/days/day-10/05-activity-10b.qmd
+++ b/content/days/day-10/05-activity-10b.qmd
@@ -22,133 +22,133 @@ Incidentally, do not be surprised if, both here and in similar Activities on Day
 
 ```{ojs}
 viewof activity_10b_point1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point1 = Inputs.textarea({label: "Comments — Point 1: Create constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 2.** [Adopt the new philosophy. We are in a new economic age, created in Japan.]{.deming_quote} *(Day 4 pages 18--19.)*
 
 ```{ojs}
 viewof activity_10b_point2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point2 = Inputs.textarea({label: "Comments — Point 2: Adopt the new philosophy", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 3.** [Eliminate the need for mass inspection as a way to achieve quality.]{.deming_quote} *(Day 4 pages 20--21.)*
 
 ```{ojs}
 viewof activity_10b_point3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point3 = Inputs.textarea({label: "Comments — Point 3: Eliminate the need for mass inspection", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 4.** [End the practice of awarding business solely on the basis of price tag.]{.deming_quote} *(Day 4 pages 22--23.)*
 
 ```{ojs}
 viewof activity_10b_point4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point4 = Inputs.textarea({label: "Comments — Point 4: End the practice of awarding business on price tag alone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 5.** [Improve constantly and for ever the system.]{.deming_quote} *(Day 4 pages 24--25.)*
 
 ```{ojs}
 viewof activity_10b_point5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point5 = Inputs.textarea({label: "Comments — Point 5: Improve constantly and forever the system", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 6.** [Institute modern methods of training.]{.deming_quote} *(Day 4 pages 26--27.)*
 
 ```{ojs}
 viewof activity_10b_point6_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point6 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point6 = Inputs.textarea({label: "Comments — Point 6: Institute modern methods of training", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 7.** [Adopt and institute leadership aimed at helping people to do a better job.]{.deming_quote} *(Day 5 pages 2--3.)*
 
 ```{ojs}
 viewof activity_10b_point7_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point7 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point7 = Inputs.textarea({label: "Comments — Point 7: Adopt and institute leadership", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 8.** [Encourage effective two-way communication and other means to drive out fear throughout the organisation.]{.deming_quote} *(Day 5 pages 4--5.)*
 
 ```{ojs}
 viewof activity_10b_point8_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point8 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point8 = Inputs.textarea({label: "Comments — Point 8: Drive out fear", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 9.** [Break down barriers between departments and staff areas.]{.deming_quote} *(Day 5 pages 6--7.)*
 
 ```{ojs}
 viewof activity_10b_point9_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point9 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point9 = Inputs.textarea({label: "Comments — Point 9: Break down barriers between departments and staff areas", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 10.** [Eliminate the use of slogans, posters, and exhortations.]{.deming_quote} *(Day 5 pages 8--9.)*
 
 ```{ojs}
 viewof activity_10b_point10_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point10 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point10 = Inputs.textarea({label: "Comments — Point 10: Eliminate slogans, posters, and exhortations", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 11.** [Eliminate work standards that prescribe quotas for the workforce and numerical goals for people in management.]{.deming_quote} *(Day 5 pages 10--11.)*
 
 ```{ojs}
 viewof activity_10b_point11_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point11 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point11 = Inputs.textarea({label: "Comments — Point 11: Eliminate work standards and numerical goals", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 12.** [Remove the barriers that rob hourly workers, and people in management, of their right to pride of workmanship.]{.deming_quote} *(Day 5 pages 12--13.)*
 
 ```{ojs}
 viewof activity_10b_point12_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point12 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point12 = Inputs.textarea({label: "Comments — Point 12: Remove barriers to pride of workmanship", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 13.** [Institute a vigorous programme of education, and encourage self-improvement for everyone.]{.deming_quote} *(Day 5 pages 14--15.)*
 
 ```{ojs}
 viewof activity_10b_point13_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point13 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point13 = Inputs.textarea({label: "Comments — Point 13: Institute education and self-improvement for everyone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 14.** [Clearly define top management's permanent commitment to ever-improving quality and productivity.]{.deming_quote} *(Day 5 pages 16--17.)*
 
 ```{ojs}
 viewof activity_10b_point14_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_point14 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_point14 = Inputs.textarea({label: "Comments — Point 14: Top management's permanent commitment to ever-improving quality", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 1.** [The crippling disease is lack of constancy of purpose.]{.deming_quote} *(Day 5 pages 18--19.)*
 
 ```{ojs}
 viewof activity_10b_disease1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_disease1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_disease1 = Inputs.textarea({label: "Comments — Disease 1: Lack of constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 2.** [Short-term thinking defeats constancy of purpose.]{.deming_quote} *(Day 5 pages 20--21.)*
 
 ```{ojs}
 viewof activity_10b_disease2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_disease2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_disease2 = Inputs.textarea({label: "Comments — Disease 2: Short-term thinking", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 3.** [The effects of performance appraisal are devastating.]{.deming_quote} *(Day 5 pages 22--23.)*
 
 ```{ojs}
 viewof activity_10b_disease3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_disease3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_disease3 = Inputs.textarea({label: "Comments — Disease 3: The devastating effects of performance appraisal", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 4.** [Mobility of management causes instability.]{.deming_quote} *(Day 5 pages 24--25.)*
 
 ```{ojs}
 viewof activity_10b_disease4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_disease4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_disease4 = Inputs.textarea({label: "Comments — Disease 4: Mobility of management causes instability", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 5.** [One cannot be successful on visible figures alone.]{.deming_quote} *(Day 5 pages 26--27.)*
 
 ```{ojs}
 viewof activity_10b_disease5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_10b_disease5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_10b_disease5 = Inputs.textarea({label: "Comments — Disease 5: Running on visible figures alone", placeholder: "Your comments.", rows: 3})
 ```
 
 </div>

--- a/content/days/day-11/02-theory-of-knowledge-prediction.qmd
+++ b/content/days/day-11/02-theory-of-knowledge-prediction.qmd
@@ -59,7 +59,7 @@ So yes, of course, managers along with others need to predict successfully. But 
 </div>
 
 ```{ojs}
-viewof note_11_prediction_1 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_prediction_1 = Inputs.textarea({label: "Your notes on item 1: rational plans require prediction", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -93,7 +93,7 @@ Dr Deming was particularly conscious of the difference between information and k
 </div>
 
 ```{ojs}
-viewof note_11_prediction_2 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_prediction_2 = Inputs.textarea({label: "Your notes on item 2: a statement devoid of prediction is no help in management", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 (Over to you now for your reactions, thoughts, comments for the rest of Part C.)
@@ -111,7 +111,7 @@ If you are a statistician, you might prefer to remain unaware of the following p
 </div>
 
 ```{ojs}
-viewof note_11_prediction_3 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_prediction_3 = Inputs.textarea({label: "Your notes on item 3: interpretation of data is prediction; statistical control aids prediction", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 #### Area 1, Step 3: *DemDim* version
@@ -119,7 +119,7 @@ viewof note_11_prediction_3 = Inputs.textarea({placeholder: "Your notes on this 
 Now briefly read through *DemDim* page 274, paragraph 1 to page 275, paragraph 4 again, revising your earlier comments if necessary and adding any further notes below.
 
 ```{ojs}
-viewof note_11_demdim_area1 = Inputs.textarea({placeholder: "Additional notes from DemDim pages 274–275.", rows: 6})
+viewof note_11_demdim_area1 = Inputs.textarea({label: "Additional notes after re-reading DemDim pages 274–275 on Prediction", placeholder: "Additional notes from DemDim pages 274–275.", rows: 6})
 ```
 
 ```{ojs download_all_11_area1}

--- a/content/days/day-11/03-theory-of-knowledge-theory-and-learning.qmd
+++ b/content/days/day-11/03-theory-of-knowledge-theory-and-learning.qmd
@@ -67,7 +67,7 @@ We are surely back to Shewhart's "dynamic scientific process of acquiring knowle
 </div>
 
 ```{ojs}
-viewof note_11_theory_4 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_theory_4 = Inputs.textarea({label: "Your notes on item 4: without theory, there is nothing to modify or to learn from", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -79,7 +79,7 @@ viewof note_11_theory_4 = Inputs.textarea({placeholder: "Your notes on this item
 </div>
 
 ```{ojs}
-viewof note_11_theory_5 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_theory_5 = Inputs.textarea({label: "Your notes on item 5: an example is no help in management unless studied with theory", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -91,7 +91,7 @@ viewof note_11_theory_5 = Inputs.textarea({placeholder: "Your notes on this item
 </div>
 
 ```{ojs}
-viewof note_11_theory_6 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_theory_6 = Inputs.textarea({label: "Your notes on item 6: examples never establish a theory, but a single failure requires its modification", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 *(Continue to Area 2, Step 3 overleaf.)*
@@ -101,7 +101,7 @@ viewof note_11_theory_6 = Inputs.textarea({placeholder: "Your notes on this item
 Now briefly read through *DemDim* pages 275--276, paragraphs 5 to 7 again, as usual revising your earlier comments if necessary and adding any further points below.
 
 ```{ojs}
-viewof note_11_demdim_area2 = Inputs.textarea({placeholder: "Additional notes from DemDim pages 275–276.", rows: 6})
+viewof note_11_demdim_area2 = Inputs.textarea({label: "Additional notes after re-reading DemDim pages 275–276 on Theory and Learning", placeholder: "Additional notes from DemDim pages 275–276.", rows: 6})
 ```
 
 ```{ojs download_all_11_area2}

--- a/content/days/day-11/04-theory-of-knowledge-operational-definitions.qmd
+++ b/content/days/day-11/04-theory-of-knowledge-operational-definitions.qmd
@@ -50,7 +50,7 @@ Pages 14--21 are also on Workbook pages 193--200.
 </div>
 
 ```{ojs}
-viewof note_11_opdef_7 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_opdef_7 = Inputs.textarea({label: "Your notes on item 7: communication and negotiation require operational definitions", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -64,7 +64,7 @@ At least I can assure you that these versions of Items 8 and 9 are rather more h
 </div>
 
 ```{ojs}
-viewof note_11_opdef_8 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_opdef_8 = Inputs.textarea({label: "Your notes on item 8: there is no true value of any characteristic defined by measurement", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -84,7 +84,7 @@ Would you trust apparently important "facts" deduced from unimportant or inappro
 </div>
 
 ```{ojs}
-viewof note_11_opdef_9 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_opdef_9 = Inputs.textarea({label: "Your notes on item 9: there is no such thing as a fact concerning an empirical observation", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 *(Continue to Area 3, Step 3 overleaf.)*
@@ -94,7 +94,7 @@ viewof note_11_opdef_9 = Inputs.textarea({placeholder: "Your notes on this item.
 And so, finally with Area 3, read through paragraphs 8--10 on *DemDim* page 276 again, revising your earlier comments and adding any new points below.
 
 ```{ojs}
-viewof note_11_demdim_area3 = Inputs.textarea({placeholder: "Additional notes from DemDim page 276.", rows: 6})
+viewof note_11_demdim_area3 = Inputs.textarea({label: "Additional notes after re-reading DemDim page 276 on Operational Definitions", placeholder: "Additional notes from DemDim page 276.", rows: 6})
 ```
 
 ### Step 3 (complete): *DemDim* version
@@ -102,7 +102,7 @@ viewof note_11_demdim_area3 = Inputs.textarea({placeholder: "Additional notes fr
 As you know, the complete *DemDim* version of Part C is on pages 274--276. So read through those three pages one more time (jotting down any final notes and revisions) to bring together all three areas into your mind before proceeding to Activity 11--a.
 
 ```{ojs}
-viewof note_11_demdim_partc_complete = Inputs.textarea({placeholder: "Final notes from DemDim pages 274–276.", rows: 6})
+viewof note_11_demdim_partc_complete = Inputs.textarea({label: "Final notes after reading the complete DemDim pages 274–276 on Theory of Knowledge", placeholder: "Final notes from DemDim pages 274–276.", rows: 6})
 ```
 
 <div class="neave_note">

--- a/content/days/day-11/05-activity-11a.qmd
+++ b/content/days/day-11/05-activity-11a.qmd
@@ -22,133 +22,133 @@ Therefore, in this Activity, you could consider alternative questions linking in
 
 ```{ojs}
 viewof activity_11a_point1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point1 = Inputs.textarea({label: "Comments — Point 1: Create constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 2.** [Adopt the new philosophy. We are in a new economic age, created in Japan.]{.deming_quote} *(Day 4 pages 18--19.)*
 
 ```{ojs}
 viewof activity_11a_point2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point2 = Inputs.textarea({label: "Comments — Point 2: Adopt the new philosophy", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 3.** [Eliminate the need for mass inspection as a way to achieve quality.]{.deming_quote} *(Day 4 pages 20--21.)*
 
 ```{ojs}
 viewof activity_11a_point3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point3 = Inputs.textarea({label: "Comments — Point 3: Eliminate the need for mass inspection", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 4.** [End the practice of awarding business solely on the basis of price tag.]{.deming_quote} *(Day 4 pages 22--23.)*
 
 ```{ojs}
 viewof activity_11a_point4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point4 = Inputs.textarea({label: "Comments — Point 4: End the practice of awarding business on price tag alone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 5.** [Improve constantly and for ever the system.]{.deming_quote} *(Day 4 pages 24--25.)*
 
 ```{ojs}
 viewof activity_11a_point5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point5 = Inputs.textarea({label: "Comments — Point 5: Improve constantly and forever the system", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 6.** [Institute modern methods of training.]{.deming_quote} *(Day 4 pages 26--27.)*
 
 ```{ojs}
 viewof activity_11a_point6_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point6 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point6 = Inputs.textarea({label: "Comments — Point 6: Institute modern methods of training", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 7.** [Adopt and institute leadership aimed at helping people to do a better job.]{.deming_quote} *(Day 5 pages 2--3.)*
 
 ```{ojs}
 viewof activity_11a_point7_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point7 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point7 = Inputs.textarea({label: "Comments — Point 7: Adopt and institute leadership", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 8.** [Encourage effective two-way communication and other means to drive out fear throughout the organisation.]{.deming_quote} *(Day 5 pages 4--5.)*
 
 ```{ojs}
 viewof activity_11a_point8_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point8 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point8 = Inputs.textarea({label: "Comments — Point 8: Drive out fear", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 9.** [Break down barriers between departments and staff areas.]{.deming_quote} *(Day 5 pages 6--7.)*
 
 ```{ojs}
 viewof activity_11a_point9_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point9 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point9 = Inputs.textarea({label: "Comments — Point 9: Break down barriers between departments and staff areas", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 10.** [Eliminate the use of slogans, posters, and exhortations.]{.deming_quote} *(Day 5 pages 8--9.)*
 
 ```{ojs}
 viewof activity_11a_point10_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point10 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point10 = Inputs.textarea({label: "Comments — Point 10: Eliminate slogans, posters, and exhortations", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 11.** [Eliminate work standards that prescribe quotas for the workforce and numerical goals for people in management.]{.deming_quote} *(Day 5 pages 10--11.)*
 
 ```{ojs}
 viewof activity_11a_point11_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point11 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point11 = Inputs.textarea({label: "Comments — Point 11: Eliminate work standards and numerical goals", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 12.** [Remove the barriers that rob hourly workers, and people in management, of their right to pride of workmanship.]{.deming_quote} *(Day 5 pages 12--13.)*
 
 ```{ojs}
 viewof activity_11a_point12_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point12 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point12 = Inputs.textarea({label: "Comments — Point 12: Remove barriers to pride of workmanship", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 13.** [Institute a vigorous programme of education, and encourage self-improvement for everyone.]{.deming_quote} *(Day 5 pages 14--15.)*
 
 ```{ojs}
 viewof activity_11a_point13_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point13 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point13 = Inputs.textarea({label: "Comments — Point 13: Institute education and self-improvement for everyone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 14.** [Clearly define top management's permanent commitment to ever-improving quality and productivity.]{.deming_quote} *(Day 5 pages 16--17.)*
 
 ```{ojs}
 viewof activity_11a_point14_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_point14 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_point14 = Inputs.textarea({label: "Comments — Point 14: Top management's permanent commitment to ever-improving quality", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 1.** [The crippling disease is lack of constancy of purpose.]{.deming_quote} *(Day 5 pages 18--19.)*
 
 ```{ojs}
 viewof activity_11a_disease1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_disease1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_disease1 = Inputs.textarea({label: "Comments — Disease 1: Lack of constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 2.** [Short-term thinking defeats constancy of purpose.]{.deming_quote} *(Day 5 pages 20--21.)*
 
 ```{ojs}
 viewof activity_11a_disease2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_disease2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_disease2 = Inputs.textarea({label: "Comments — Disease 2: Short-term thinking", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 3.** [The effects of performance appraisal are devastating.]{.deming_quote} *(Day 5 pages 22--23.)*
 
 ```{ojs}
 viewof activity_11a_disease3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_disease3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_disease3 = Inputs.textarea({label: "Comments — Disease 3: The devastating effects of performance appraisal", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 4.** [Mobility of management causes instability.]{.deming_quote} *(Day 5 pages 24--25.)*
 
 ```{ojs}
 viewof activity_11a_disease4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_disease4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_disease4 = Inputs.textarea({label: "Comments — Disease 4: Mobility of management causes instability", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 5.** [One cannot be successful on visible figures alone.]{.deming_quote} *(Day 5 pages 26--27.)*
 
 ```{ojs}
 viewof activity_11a_disease5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11a_disease5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11a_disease5 = Inputs.textarea({label: "Comments — Disease 5: Running on visible figures alone", placeholder: "Your comments.", rows: 3})
 ```
 
 </div>

--- a/content/days/day-11/06-knowledge-of-psychology.qmd
+++ b/content/days/day-11/06-knowledge-of-psychology.qmd
@@ -37,7 +37,7 @@ Note also that, as you would expect, Deming concentrates in this opening stateme
 </div>
 
 ```{ojs}
-viewof note_11_psych_1 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_psych_1 = Inputs.textarea({label: "Your notes on item 1: psychology helps us understand people and interactions", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -57,7 +57,7 @@ Finally, isn't effort greatly dependent on the way an individual reacts to, and 
 </div>
 
 ```{ojs}
-viewof note_11_psych_2 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_psych_2 = Inputs.textarea({label: "Your notes on item 2: people are different from one another", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 (Now, for the final time, I hand over to you to write your thoughts and comments in the gaps provided, with the help of my guidance for Step 2 of the four-step procedure.)
@@ -67,7 +67,7 @@ viewof note_11_psych_2 = Inputs.textarea({placeholder: "Your notes on this item.
 </div>
 
 ```{ojs}
-viewof note_11_psych_3 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_psych_3 = Inputs.textarea({label: "Your notes on item 3: people learn in different ways and at different speeds", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -79,7 +79,7 @@ viewof note_11_psych_3 = Inputs.textarea({placeholder: "Your notes on this item.
 </div>
 
 ```{ojs}
-viewof note_11_psych_4 = Inputs.textarea({placeholder: "Your notes on this item.", rows: 4})
+viewof note_11_psych_4 = Inputs.textarea({label: "Your notes on item 4: a leader's obligation to make changes that bring improvement", placeholder: "Your notes on this item.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -105,7 +105,7 @@ All that follows on the next five and a half pages concerns these matters.]
 </div>
 
 ```{ojs}
-viewof note_11_psych_5a = Inputs.textarea({placeholder: "Your notes.", rows: 4})
+viewof note_11_psych_5a = Inputs.textarea({label: "Your notes on item 5a: innate need for relationships, love, and self-esteem", placeholder: "Your notes.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -121,7 +121,7 @@ viewof note_11_psych_5a = Inputs.textarea({placeholder: "Your notes.", rows: 4})
 </div>
 
 ```{ojs}
-viewof note_11_psych_5b = Inputs.textarea({placeholder: "Your notes.", rows: 4})
+viewof note_11_psych_5b = Inputs.textarea({label: "Your notes on item 5b: how circumstances and management affect dignity, self-esteem, and intrinsic motivation", placeholder: "Your notes.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -145,7 +145,7 @@ viewof note_11_psych_5b = Inputs.textarea({placeholder: "Your notes.", rows: 4})
 </div>
 
 ```{ojs}
-viewof note_11_psych_5c = Inputs.textarea({placeholder: "Your notes.", rows: 4})
+viewof note_11_psych_5c = Inputs.textarea({label: "Your notes on item 5c: extrinsic motivators that rob dignity, and the harm of grading", placeholder: "Your notes.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -169,7 +169,7 @@ Regarding these matters, recall also the reference to Norb Keller of General Mot
 </div>
 
 ```{ojs}
-viewof note_11_psych_5d = Inputs.textarea({placeholder: "Your notes.", rows: 4})
+viewof note_11_psych_5d = Inputs.textarea({label: "Your notes on item 5d: the natural inclination to learn, and 'pay is not a motivator'", placeholder: "Your notes.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -185,7 +185,7 @@ viewof note_11_psych_5d = Inputs.textarea({placeholder: "Your notes.", rows: 4})
 </div>
 
 ```{ojs}
-viewof note_11_psych_5e = Inputs.textarea({placeholder: "Your notes.", rows: 4})
+viewof note_11_psych_5e = Inputs.textarea({label: "Your notes on item 5e: extrinsic motivation as a Zero-Defect mentality, and removal of demotivators", placeholder: "Your notes.", rows: 4})
 ```
 
 <div class="deming_quote">
@@ -209,7 +209,7 @@ viewof note_11_psych_5e = Inputs.textarea({placeholder: "Your notes.", rows: 4})
 </div>
 
 ```{ojs}
-viewof note_11_psych_5f = Inputs.textarea({placeholder: "Your notes.", rows: 4})
+viewof note_11_psych_5f = Inputs.textarea({label: "Your notes on item 5f: overjustification and monetary reward as a manager's way out", placeholder: "Your notes.", rows: 4})
 ```
 
 ### Step 3: *DemDim* version
@@ -217,7 +217,7 @@ viewof note_11_psych_5f = Inputs.textarea({placeholder: "Your notes.", rows: 4})
 Now read through *DemDim* pages 277--279 again, revising your earlier comments and adding new thoughts below.
 
 ```{ojs}
-viewof note_11_demdim_partd = Inputs.textarea({placeholder: "Additional notes from DemDim pages 277–279.", rows: 6})
+viewof note_11_demdim_partd = Inputs.textarea({label: "Additional notes after re-reading DemDim pages 277–279 on Knowledge of Psychology", placeholder: "Additional notes from DemDim pages 277–279.", rows: 6})
 ```
 
 <div class="neave_note">

--- a/content/days/day-11/07-activity-11b.qmd
+++ b/content/days/day-11/07-activity-11b.qmd
@@ -20,133 +20,133 @@ Last lap! As previously, but now in connection with Part D: "Knowledge of Psycho
 
 ```{ojs}
 viewof activity_11b_point1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point1 = Inputs.textarea({label: "Comments — Point 1: Create constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 2.** [Adopt the new philosophy. We are in a new economic age, created in Japan.]{.deming_quote} *(Day 4 pages 18--19.)*
 
 ```{ojs}
 viewof activity_11b_point2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point2 = Inputs.textarea({label: "Comments — Point 2: Adopt the new philosophy", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 3.** [Eliminate the need for mass inspection as a way to achieve quality.]{.deming_quote} *(Day 4 pages 20--21.)*
 
 ```{ojs}
 viewof activity_11b_point3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point3 = Inputs.textarea({label: "Comments — Point 3: Eliminate the need for mass inspection", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 4.** [End the practice of awarding business solely on the basis of price tag.]{.deming_quote} *(Day 4 pages 22--23.)*
 
 ```{ojs}
 viewof activity_11b_point4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point4 = Inputs.textarea({label: "Comments — Point 4: End the practice of awarding business on price tag alone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 5.** [Improve constantly and for ever the system.]{.deming_quote} *(Day 4 pages 24--25.)*
 
 ```{ojs}
 viewof activity_11b_point5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point5 = Inputs.textarea({label: "Comments — Point 5: Improve constantly and forever the system", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 6.** [Institute modern methods of training.]{.deming_quote} *(Day 4 pages 26--27.)*
 
 ```{ojs}
 viewof activity_11b_point6_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point6 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point6 = Inputs.textarea({label: "Comments — Point 6: Institute modern methods of training", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 7.** [Adopt and institute leadership aimed at helping people to do a better job.]{.deming_quote} *(Day 5 pages 2--3.)*
 
 ```{ojs}
 viewof activity_11b_point7_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point7 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point7 = Inputs.textarea({label: "Comments — Point 7: Adopt and institute leadership", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 8.** [Encourage effective two-way communication and other means to drive out fear throughout the organisation.]{.deming_quote} *(Day 5 pages 4--5.)*
 
 ```{ojs}
 viewof activity_11b_point8_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point8 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point8 = Inputs.textarea({label: "Comments — Point 8: Drive out fear", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 9.** [Break down barriers between departments and staff areas.]{.deming_quote} *(Day 5 pages 6--7.)*
 
 ```{ojs}
 viewof activity_11b_point9_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point9 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point9 = Inputs.textarea({label: "Comments — Point 9: Break down barriers between departments and staff areas", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 10.** [Eliminate the use of slogans, posters, and exhortations.]{.deming_quote} *(Day 5 pages 8--9.)*
 
 ```{ojs}
 viewof activity_11b_point10_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point10 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point10 = Inputs.textarea({label: "Comments — Point 10: Eliminate slogans, posters, and exhortations", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 11.** [Eliminate work standards that prescribe quotas for the workforce and numerical goals for people in management.]{.deming_quote} *(Day 5 pages 10--11.)*
 
 ```{ojs}
 viewof activity_11b_point11_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point11 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point11 = Inputs.textarea({label: "Comments — Point 11: Eliminate work standards and numerical goals", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 12.** [Remove the barriers that rob hourly workers, and people in management, of their right to pride of workmanship.]{.deming_quote} *(Day 5 pages 12--13.)*
 
 ```{ojs}
 viewof activity_11b_point12_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point12 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point12 = Inputs.textarea({label: "Comments — Point 12: Remove barriers to pride of workmanship", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 13.** [Institute a vigorous programme of education, and encourage self-improvement for everyone.]{.deming_quote} *(Day 5 pages 14--15.)*
 
 ```{ojs}
 viewof activity_11b_point13_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point13 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point13 = Inputs.textarea({label: "Comments — Point 13: Institute education and self-improvement for everyone", placeholder: "Your comments.", rows: 3})
 ```
 
 **POINT 14.** [Clearly define top management's permanent commitment to ever-improving quality and productivity.]{.deming_quote} *(Day 5 pages 16--17.)*
 
 ```{ojs}
 viewof activity_11b_point14_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_point14 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_point14 = Inputs.textarea({label: "Comments — Point 14: Top management's permanent commitment to ever-improving quality", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 1.** [The crippling disease is lack of constancy of purpose.]{.deming_quote} *(Day 5 pages 18--19.)*
 
 ```{ojs}
 viewof activity_11b_disease1_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_disease1 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_disease1 = Inputs.textarea({label: "Comments — Disease 1: Lack of constancy of purpose", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 2.** [Short-term thinking defeats constancy of purpose.]{.deming_quote} *(Day 5 pages 20--21.)*
 
 ```{ojs}
 viewof activity_11b_disease2_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_disease2 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_disease2 = Inputs.textarea({label: "Comments — Disease 2: Short-term thinking", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 3.** [The effects of performance appraisal are devastating.]{.deming_quote} *(Day 5 pages 22--23.)*
 
 ```{ojs}
 viewof activity_11b_disease3_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_disease3 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_disease3 = Inputs.textarea({label: "Comments — Disease 3: The devastating effects of performance appraisal", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 4.** [Mobility of management causes instability.]{.deming_quote} *(Day 5 pages 24--25.)*
 
 ```{ojs}
 viewof activity_11b_disease4_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_disease4 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_disease4 = Inputs.textarea({label: "Comments — Disease 4: Mobility of management causes instability", placeholder: "Your comments.", rows: 3})
 ```
 
 **DISEASE 5.** [One cannot be successful on visible figures alone.]{.deming_quote} *(Day 5 pages 26--27.)*
 
 ```{ojs}
 viewof activity_11b_disease5_rating = Inputs.text({label: "Rating (0–5):", placeholder: "0–5"})
-viewof activity_11b_disease5 = Inputs.textarea({placeholder: "Your comments.", rows: 3})
+viewof activity_11b_disease5 = Inputs.textarea({label: "Comments — Disease 5: Running on visible figures alone", placeholder: "Your comments.", rows: 3})
 ```
 
 *Please move to the next page for the conclusion.*

--- a/content/days/day-12/04-but-what-can-i-do.qmd
+++ b/content/days/day-12/04-but-what-can-i-do.qmd
@@ -32,7 +32,7 @@ Pause for Thought 12–c is also on Workbook page 219.
 What do you understand by Dr Deming's second short sentence above: [This transformation is discontinuous]{.deming_quote}?
 
 ```{ojs}
-viewof thought_12c = Inputs.textarea({placeholder: "Your thoughts.", rows: 4})
+viewof thought_12c = Inputs.textarea({label: "What do you understand by Dr Deming's second short sentence: 'This transformation is discontinuous'?", placeholder: "Your thoughts.", rows: 4})
 ```
 
 </div>

--- a/content/days/day-12/06-activity-12d.qmd
+++ b/content/days/day-12/06-activity-12d.qmd
@@ -46,7 +46,7 @@ Jot down your answers to some of these questions and other notes either in the s
 *(You will note that my guidance allows you plenty of time for this Activity. You may well need yet more.)*
 
 ```{ojs}
-viewof activity_12d = Inputs.textarea({placeholder: "Your notes for Activity 12–d.", rows: 12})
+viewof activity_12d = Inputs.textarea({label: "Your notes and answers for Activity 12–d", placeholder: "Your notes for Activity 12–d.", rows: 12})
 ```
 
 ```{ojs download_12d}

--- a/content/days/day-12/07-major-activity-12e.qmd
+++ b/content/days/day-12/07-major-activity-12e.qmd
@@ -37,7 +37,7 @@ If you would like to see a couple of examples of such reports, and have availabl
 *(The following three pages have been left blank for Dr Deming's draft report.)*
 
 ```{ojs}
-viewof activity_12e_part1 = Inputs.textarea({placeholder: "Draft your 'Deming report' to the Chief Executive here.", rows: 16})
+viewof activity_12e_part1 = Inputs.textarea({label: "Part 1: Draft Dr Deming's report to your organisation's Chief Executive", placeholder: "Draft your 'Deming report' to the Chief Executive here.", rows: 16})
 ```
 
 ### Part 2
@@ -57,7 +57,7 @@ Since you have now nearly completed this course, assume you have been promoted t
 *(The following three pages have been left blank for your thoughts and ideas.)*
 
 ```{ojs}
-viewof activity_12e_part2 = Inputs.textarea({placeholder: "Your plans and thoughts for Part 2 (Option 1 or Option 2).", rows: 16})
+viewof activity_12e_part2 = Inputs.textarea({label: "Part 2: Your plans for change (Option 1) or your work as 'aide to the president' (Option 2)", placeholder: "Your plans and thoughts for Part 2 (Option 1 or Option 2).", rows: 16})
 ```
 
 ```{ojs download_12e}

--- a/content/days/day-12/08-epilogue.qmd
+++ b/content/days/day-12/08-epilogue.qmd
@@ -27,7 +27,7 @@ industrial rebirth and its worldwide success to W Edwards Deming. No honour amon
 
 *Dr Deming:* Oh, it was a matter of luck.
 
-![The Second Order Medal of the Sacred Treasure, awarded to Dr Deming by the Emperor of Japan](/assets/images/day-12/deming-medal.png){fig-align=”center” width=”30%” .lightbox}
+![The Second Order Medal of the Sacred Treasure, awarded to Dr Deming by the Emperor of Japan](/assets/images/day-12/deming-medal.png){fig-align="center" width="30%" .lightbox}
 
 *Narrator:* Quite obviously, a grateful Japanese people don’t share Dr Deming’s humble view that it was only “a matter of luck”. Each year, since 1951, the Japanese have awarded a medal named in Dr Deming’s honour to those companies which have attained the highest level of quality. His presence at an award ceremony ... is considered the ultimate honour.
 


### PR DESCRIPTION
## Summary
- Adds descriptive `label:` parameters to 175 Observable Inputs across Days 7-12 (closes #147), restoring screen-reader and voice-control accessibility (WCAG 2.5.3 Label in Name, 3.3.2 Labels or Instructions). Days 1-6 already had labels; Days 1-2 served as the pattern reference.
- Fixes smart quotes around `fig-align` and `width` on the Deming medal image in `day-12/08-epilogue.qmd`, which were triggering an "Invalid alignment attribute value" warning during `quarto render`.

## Test plan
- [ ] `quarto render` runs without the alignment warning
- [ ] Spot-check a labelled input on Day 10/11 (the activity grids) — the label appears above the textarea instead of just placeholder text
- [ ] Inspect the rendered medal image on Day 12 epilogue to confirm 30% width + centred alignment
- [ ] Verify download buttons on activities still capture the inputs (label change is additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)