### PR TITLE
Prevent dyslexia-font toggle from covering page-nav on mobile

### DIFF
--- a/assets/scripts/font-toggle.js
+++ b/assets/scripts/font-toggle.js
@@ -33,6 +33,7 @@
     button.type = "button";
     button.className = "dyslexia-toggle";
     button.setAttribute("aria-pressed", initialOn ? "true" : "false");
+    button.setAttribute("aria-label", "Dyslexia font");
     button.innerHTML =
       '<span class="dyslexia-toggle-icon" aria-hidden="true">Aa</span>' +
       '<span class="dyslexia-toggle-label">Dyslexia font</span>';
@@ -45,11 +46,25 @@
     });
 
     document.body.appendChild(button);
+    return button;
+  }
+
+  function yieldToPageNav(button) {
+    if (!("IntersectionObserver" in window)) return;
+    var nav = document.querySelector(".page-navigation");
+    if (!nav) return;
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        button.classList.toggle("is-yielding", entry.isIntersecting);
+      });
+    });
+    observer.observe(nav);
   }
 
   document.addEventListener("DOMContentLoaded", function () {
     var on = isEnabled();
     applyClass(on);
-    build(on);
+    var button = build(on);
+    yieldToPageNav(button);
   });
 })();

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -772,6 +772,7 @@ button:focus,
   border-radius: 6px;
   cursor: pointer;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: opacity 200ms ease, transform 200ms ease;
 }
 .dyslexia-toggle:hover {
   background-color: #e8e8f4;
@@ -790,6 +791,32 @@ button:focus,
 .dyslexia-toggle .dyslexia-toggle-icon {
   font-weight: 700;
   margin-right: 6px;
+}
+.dyslexia-toggle.is-yielding {
+  opacity: 0;
+  transform: translateY(120%);
+  pointer-events: none;
+}
+
+@media (max-width: 700px) {
+  .dyslexia-toggle {
+    padding: 10px;
+    min-width: 44px;
+  }
+  .dyslexia-toggle .dyslexia-toggle-icon {
+    margin-right: 0;
+  }
+  .dyslexia-toggle .dyslexia-toggle-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 }
 
 @media print {


### PR DESCRIPTION
## Summary

- Collapse the floating dyslexia-font toggle to a 44×44 icon-only square under 700px so it no longer eats a large footprint at the bottom of the viewport on phones.
- Use `IntersectionObserver` on Quarto's `.page-navigation` element to slide the toggle out of view (fade + translate + `pointer-events: none`) while the next/prev links are on screen, then restore it as soon as the user scrolls back up.
- Add an explicit `aria-label="Dyslexia font"` so the accessible name is preserved when the visible label text is visually-hidden on mobile.

## Why

On narrow viewports the fixed toggle was sitting directly on top of Quarto's bottom-right "next page" link, making the nav link hard or impossible to tap when scrolled to the bottom of a page.

## Test plan

- [ ] `quarto preview` and confirm desktop behaviour is unchanged (pill-shaped button with "Aa Dyslexia font" label, persists across pages via `localStorage`)
- [ ] Resize the viewport below 700px wide and confirm the toggle collapses to a 44×44 square with just "Aa" visible
- [ ] Scroll to the bottom of any chapter and confirm the toggle fades/slides out of the way so the `.page-navigation` next/prev links are fully tappable
- [ ] Scroll back up and confirm the toggle reappears
- [ ] Tab to the toggle with the keyboard and confirm focus outline is still visible, aria-pressed still toggles, and screen readers still announce "Dyslexia font, toggle button"
- [ ] Verify `prefers-reduced-motion: reduce` users don't see the slide/fade animation (handled by the existing global reduced-motion rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)