### PR TITLE
Make funnel status updates reliably announce to screen readers (#161)

### DIFF
--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -460,7 +460,10 @@ export function renderStatusHTML(rule, description, counter, visible, totalStage
 
   // Announce state changes to screen readers via the persistent live region.
   // Skip counter === 0 so the initial page render doesn't spam announcements
-  // before the user has interacted.
+  // before the user has interacted. Assumes OJS only re-evaluates this cell
+  // when rule2Counter/rule2Visible (etc.) actually change — i.e. on user
+  // clicks. If a future change introduces non-interaction re-runs with the
+  // same counter, those would produce duplicate announcements.
   if (counter > 0) {
     announceFunnelStatus(
       `Rule ${rule}, stage ${counter} of ${totalStages}. Marble at ${lastOutcome}. ${funnelLabel} ${funnelPos}.`

--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -397,6 +397,56 @@ export function renderDataTable(rule, stages, tableIndex) {
   return html;
 }
 
+// --- Screen reader live region ---
+// OJS replaces a cell's output element on each re-render, so an aria-live
+// attribute on the visible `.fe-status` isn't reliably announced — screen
+// readers monitor nodes that persist across mutations. A single persistent,
+// visually-hidden live region appended once to the document is the pattern
+// VoiceOver/NVDA pick up consistently.
+
+let feLiveRegion = null;
+
+function ensureLiveRegion() {
+  if (typeof document === "undefined") return null;
+  if (feLiveRegion && feLiveRegion.isConnected) return feLiveRegion;
+  // Prefer attaching inside the Quarto main-content landmark. VoiceOver
+  // is more reliable monitoring live regions that sit inside <main> than
+  // those orphaned at <body> level.
+  const host = document.getElementById("quarto-document-content") || document.body;
+  if (!host) return null;
+  feLiveRegion = document.createElement("div");
+  feLiveRegion.className = "fe-sr-live";
+  feLiveRegion.setAttribute("role", "status");
+  feLiveRegion.setAttribute("aria-live", "polite");
+  feLiveRegion.setAttribute("aria-atomic", "true");
+  host.appendChild(feLiveRegion);
+  return feLiveRegion;
+}
+
+// Create the region eagerly at module load so assistive tech is already
+// monitoring it before the user's first interaction. Creating it on the
+// first announcement is too late — screen readers swallow the mutation
+// when the element is inserted and written in the same task.
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", ensureLiveRegion, { once: true });
+  } else {
+    ensureLiveRegion();
+  }
+}
+
+export function announceFunnelStatus(message) {
+  const el = ensureLiveRegion();
+  if (!el) return;
+  // Delay the write so VoiceOver can finish the web-area/landmark
+  // announcement it emits when OJS replaces the focused button on
+  // re-render. Without this delay, VO collapses the landmark chatter
+  // and our polite message into a single transition and drops ours.
+  setTimeout(() => {
+    if (feLiveRegion === el) el.textContent = message;
+  }, 200);
+}
+
 // --- Chapter-level helpers ---
 // These reduce duplication across OJS cells in chapters 11 and 12.
 // Each returns an HTML string; OJS cells wrap with html`${...}`.
@@ -408,7 +458,16 @@ export function renderStatusHTML(rule, description, counter, visible, totalStage
   const funnelPos = counter > 0 ? visible[visible.length - 1].funnelAfter : target;
   const funnelLabel = rule === 1 ? "Funnel always at" : (counter > 0 ? "Funnel now at" : "Funnel at");
 
-  let s = `<div class="fe-status" role="status" aria-live="polite" aria-atomic="true">`;
+  // Announce state changes to screen readers via the persistent live region.
+  // Skip counter === 0 so the initial page render doesn't spam announcements
+  // before the user has interacted.
+  if (counter > 0) {
+    announceFunnelStatus(
+      `Rule ${rule}, stage ${counter} of ${totalStages}. Marble at ${lastOutcome}. ${funnelLabel} ${funnelPos}.`
+    );
+  }
+
+  let s = `<div class="fe-status">`;
   s += `<strong>Rule ${rule} — ${description}</strong><br>`;
   s += `Stage: <strong>${counter}</strong> of ${totalStages}`;
   if (lastOutcome !== null) {

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -674,6 +674,21 @@ button:focus,
   color: #333;
 }
 
+/* Persistent visually-hidden live region for screen reader announcements.
+   Kept in the DOM across OJS re-renders so status updates are reliably
+   announced (the visible .fe-status is replaced on each render). */
+.fe-sr-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Comparison grid (2×2 charts) */
 .fe-comparison-grid {
   display: grid;


### PR DESCRIPTION
## Summary

- Funnel experiment status bars on Day 3 (chapters 11 and 12) had `aria-live="polite"` attrs, but OJS reactivity replaces the `.fe-status` element on each re-render — screen readers only monitor live regions that persist across mutations, so the announcements were being dropped.
- Added a single persistent, visually-hidden `.fe-sr-live` region created at module load and attached inside Quarto's `#quarto-document-content` landmark. A new `announceFunnelStatus()` helper writes plain-text updates into it.
- Added a 200ms write delay so VoiceOver can finish announcing the web-area landmark (triggered by OJS also destroying the focused "Next Stage" button on re-render) before our polite message enters the queue — without the delay, VO collapses both into a single transition and drops ours.
- Removed the now-misleading `role="status" aria-live="polite" aria-atomic="true"` attributes from the visible `.fe-status` div inside `renderStatusHTML` (they implied a working live region that never worked, and keeping both risks double-announcements in browsers that do pick up dynamically-added regions).
- Announcements are skipped while `counter === 0` so the initial page render (where every OJS cell evaluates eagerly) doesn't spam "Rule 1, stage 0 of 40…" / "Rule 2, stage 0 of 40…" before the user has touched anything.

Closes #161.

## Test plan

- [x] JS module parses (`node --check`)
- [x] Manual: verified with VoiceOver on Day 3 ch. 11 — clicking "Next Stage" now produces a spoken status update ("Rule 2, stage 1 of 40. Marble at 33. Funnel now at 27") after the landmark announcement settles.
- [x] Verified via Safari Web Inspector that `.fe-sr-live` is inserted into the DOM at page load (not on first click) and that its `textContent` updates on each interaction.
- [ ] No visual regression to the blue `.fe-status` bar — same copy, same styling.
- [ ] Covers all four rules' status bars (Rules 1, 2, 3, 4) because they all go through `renderStatusHTML`.

## Known follow-up (out of scope)

OJS also replaces the "Next Stage" button on each re-render, so keyboard focus falls to `<body>` and VoiceOver announces the web-area landmark on every click. That's a separate usability bug and warrants its own issue — the fix is either to preserve focus across re-render or to move the button outside the reactive cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)