### PR TITLE
Restore keyboard focus to funnel stage buttons after OJS re-render

### DIFF
--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -502,6 +502,12 @@ export function renderStageButtonsHTML(counter, totalStages) {
 // destroyed and focus falls to <body>. Screen readers then announce the
 // web-area landmark on every click (see issue #178).
 //
+// Call this synchronously *after* the `mutable counter = ...` assignment that
+// triggers the re-render. OJS schedules cell re-evaluation on a microtask,
+// so the observer registered here is guaranteed to be in place before the
+// DOM swap. Moving the call before the mutation, or deferring it to a
+// setTimeout, would break that ordering guarantee.
+//
 // currentEl: the button container from the current render. Must be passed in
 //   while it is still mounted, so we can capture `.parentElement` — the
 //   cell's output slot, which persists across re-renders.
@@ -516,7 +522,11 @@ export function restoreStageFocus(currentEl, preferred = ".fe-stage-next") {
   const observer = new MutationObserver(() => {
     const next = cellContainer.querySelector(".fe-stage-next");
     const complete = cellContainer.querySelector(".fe-stage-complete");
-    if (!next && !complete) return;
+    // Wait until both buttons are mounted. `renderStageButtonsHTML` emits
+    // them in a single HTML string so they typically arrive together, but
+    // observer callbacks can fire mid-insertion — guarding on both avoids
+    // focusing a fallback that simply hasn't been mounted yet.
+    if (!next || !complete) return;
 
     observer.disconnect();
     const primary = preferred === ".fe-stage-complete" ? complete : next;

--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -496,6 +496,47 @@ export function renderStageButtonsHTML(counter, totalStages) {
        + `<button class="fe-button fe-button-complete fe-stage-complete"${d}>Complete Remaining Stages</button></div>`;
 }
 
+// Restore keyboard focus after an OJS re-render replaces the button container.
+// OJS mutates the counter inside the click handler, which re-evaluates the
+// cell and swaps the returned element — so the just-clicked button is
+// destroyed and focus falls to <body>. Screen readers then announce the
+// web-area landmark on every click (see issue #178).
+//
+// currentEl: the button container from the current render. Must be passed in
+//   while it is still mounted, so we can capture `.parentElement` — the
+//   cell's output slot, which persists across re-renders.
+// preferred: '.fe-stage-next' or '.fe-stage-complete' — the button the user
+//   activated. If it is disabled in the replacement DOM, we fall back to the
+//   other button so keyboard flow continues gracefully.
+export function restoreStageFocus(currentEl, preferred = ".fe-stage-next") {
+  if (typeof MutationObserver === "undefined" || !currentEl) return;
+  const cellContainer = currentEl.parentElement;
+  if (!cellContainer) return;
+
+  const observer = new MutationObserver(() => {
+    const next = cellContainer.querySelector(".fe-stage-next");
+    const complete = cellContainer.querySelector(".fe-stage-complete");
+    if (!next && !complete) return;
+
+    observer.disconnect();
+    const primary = preferred === ".fe-stage-complete" ? complete : next;
+    const fallback = primary === next ? complete : next;
+    const target = primary && !primary.disabled
+      ? primary
+      : fallback && !fallback.disabled
+        ? fallback
+        : null;
+    if (target) target.focus();
+    // If both are disabled (final stage), focus has already dropped to
+    // <body>. Future enhancement: move focus to the histogram container
+    // that appears once the run completes.
+  });
+  observer.observe(cellContainer, { childList: true, subtree: true });
+  // Safety cap — disconnect if OJS never inserts replacement buttons
+  // (e.g. the cell errored). Prevents the observer from outliving the click.
+  setTimeout(() => observer.disconnect(), 1000);
+}
+
 // Three sub-tables wrapped in scroll containers (indices 0/1/2 → stages 1-14, 15-27, 28-40)
 export function renderDataTablesHTML(rule, visible) {
   return `<div class="fe-track-container">${renderDataTable(rule, visible, 0)}</div>`

--- a/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
+++ b/content/days/day-03/11-the-first-two-rules-of-the-funnel.qmd
@@ -49,6 +49,7 @@ import {
   generateDiceSequence, saveDiceSequence, loadDiceSequence,
   runAllStages, renderStatusHTML, renderTrackHTML,
   renderStageButtonsHTML, renderDataTablesHTML,
+  restoreStageFocus,
   TARGET, TOTAL_STAGES
 } from "../../../assets/scripts/funnel-experiment.js"
 ```
@@ -100,10 +101,14 @@ html`${renderTrackHTML(rule2Visible, rule2AllStages)}`
 {
   const el = html`${renderStageButtonsHTML(rule2Counter, TOTAL_STAGES)}`;
   el.querySelector('.fe-stage-next').onclick = () => {
-    if (rule2Counter < TOTAL_STAGES) mutable rule2Counter = rule2Counter + 1;
+    if (rule2Counter < TOTAL_STAGES) {
+      mutable rule2Counter = rule2Counter + 1;
+      restoreStageFocus(el, '.fe-stage-next');
+    }
   };
   el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule2Counter = TOTAL_STAGES;
+    restoreStageFocus(el, '.fe-stage-complete');
   };
   return el;
 }
@@ -192,10 +197,14 @@ html`${renderTrackHTML(rule1Visible, rule1AllStages)}`
 {
   const el = html`${renderStageButtonsHTML(rule1Counter, TOTAL_STAGES)}`;
   el.querySelector('.fe-stage-next').onclick = () => {
-    if (rule1Counter < TOTAL_STAGES) mutable rule1Counter = rule1Counter + 1;
+    if (rule1Counter < TOTAL_STAGES) {
+      mutable rule1Counter = rule1Counter + 1;
+      restoreStageFocus(el, '.fe-stage-next');
+    }
   };
   el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule1Counter = TOTAL_STAGES;
+    restoreStageFocus(el, '.fe-stage-complete');
   };
   return el;
 }

--- a/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
+++ b/content/days/day-03/12-rules-3-and-4-of-the-funnel.qmd
@@ -43,6 +43,7 @@ import {
   generateDiceSequence, saveDiceSequence, loadDiceSequence,
   runAllStages, renderStatusHTML, renderTrackHTML,
   renderStageButtonsHTML, renderDataTablesHTML,
+  restoreStageFocus,
   TARGET, TOTAL_STAGES
 } from "../../../assets/scripts/funnel-experiment.js"
 ```
@@ -91,10 +92,14 @@ html`${renderTrackHTML(rule3Visible, rule3AllStages)}`
 {
   const el = html`${renderStageButtonsHTML(rule3Counter, TOTAL_STAGES)}`;
   el.querySelector('.fe-stage-next').onclick = () => {
-    if (rule3Counter < TOTAL_STAGES) mutable rule3Counter = rule3Counter + 1;
+    if (rule3Counter < TOTAL_STAGES) {
+      mutable rule3Counter = rule3Counter + 1;
+      restoreStageFocus(el, '.fe-stage-next');
+    }
   };
   el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule3Counter = TOTAL_STAGES;
+    restoreStageFocus(el, '.fe-stage-complete');
   };
   return el;
 }
@@ -195,10 +200,14 @@ html`${renderTrackHTML(rule4Visible, rule4AllStages)}`
 {
   const el = html`${renderStageButtonsHTML(rule4Counter, TOTAL_STAGES)}`;
   el.querySelector('.fe-stage-next').onclick = () => {
-    if (rule4Counter < TOTAL_STAGES) mutable rule4Counter = rule4Counter + 1;
+    if (rule4Counter < TOTAL_STAGES) {
+      mutable rule4Counter = rule4Counter + 1;
+      restoreStageFocus(el, '.fe-stage-next');
+    }
   };
   el.querySelector('.fe-stage-complete').onclick = () => {
     mutable rule4Counter = TOTAL_STAGES;
+    restoreStageFocus(el, '.fe-stage-complete');
   };
   return el;
 }


### PR DESCRIPTION
## Summary

- Adds `restoreStageFocus(currentEl, preferred)` to `assets/scripts/funnel-experiment.js`. The helper captures the cell's output slot at click time (before OJS orphans the old element) and uses a `MutationObserver` to refocus the matching button in the replacement DOM — with a graceful fallback to the sibling button when the preferred one is disabled.
- Wires the helper into the four stage-button OJS cells in Day 3 chapters 11 and 12 (Rules 1–4), so Space/Enter activation no longer drops focus to `<body>`.
- Eliminates the "12 days to deming, web content" landmark re-announcement that VoiceOver emitted on every click — which was both annoying on its own and partially drowned out the aria-live status messages introduced by #161.

## Why

Issue #178: OJS cells re-evaluate whenever their reactive dependencies change. The stage-button cell reads `ruleNCounter`, so mutating the counter replaces the cell's output DOM — including the focused button. Keyboard users lost their place in the tab order on every interaction (WCAG 2.4.3, 3.2.1).

This implements Option 1 from the issue (smallest change). The structurally cleaner Option 2 — flipping `disabled` in place on a persistent DOM node — would require restructuring the OJS cells to break the counter dependency, and is a fine follow-up if we want to silence the per-click "Next Stage, button" role re-announcement VoiceOver still emits.

Closes #178.

## Test plan

- [ ] `quarto preview` the Day 3 chapter 11 page.
- [ ] **Keyboard-only:** Tab to "Next Stage" on the Rule 2 funnel, press Space repeatedly. Confirm each press advances the stage without re-tabbing (focus remains on the button).
- [ ] Repeat for Rule 1 (same page), Rule 3, and Rule 4 (chapter 12).
- [ ] **VoiceOver (Safari):** With VO on, Tab to "Next Stage", activate. Confirm VO no longer announces "12 days to deming, web content" on each click. The expected sequence is "Next Stage, button" → the polite live-region status update.
- [ ] **Complete Remaining Stages:** Click it mid-run. Confirm the button sequence still behaves (counter jumps to 40, both buttons disable; focus lands somewhere reasonable — for now, acceptably lost on this final transition since both are disabled).
- [ ] **Mouse:** Normal click behaviour unchanged; counter still increments, tables/track/status update as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)