### PR TITLE
Consolidate visually-hidden CSS and migrate off deprecated clip

### DIFF
--- a/assets/scripts/font-toggle.js
+++ b/assets/scripts/font-toggle.js
@@ -46,7 +46,29 @@
     });
 
     document.body.appendChild(button);
+    syncLabelVisibility(button);
     return button;
+  }
+
+  function syncLabelVisibility(button) {
+    // On narrow viewports the button collapses to icon-only, with the
+    // label visually hidden but still announced by screen readers
+    // (aria-label on the button + the live label text both contribute).
+    // matchMedia keeps this in sync across viewport-size changes without
+    // duplicating the hiding rule in CSS.
+    var label = button.querySelector(".dyslexia-toggle-label");
+    if (!label || !window.matchMedia) return;
+    var mq = window.matchMedia("(max-width: 700px)");
+    function sync() {
+      label.classList.toggle("visually-hidden", mq.matches);
+    }
+    sync();
+    if (mq.addEventListener) {
+      mq.addEventListener("change", sync);
+    } else if (mq.addListener) {
+      // Safari < 14 fallback
+      mq.addListener(sync);
+    }
   }
 
   function yieldToPageNav(button) {

--- a/assets/scripts/font-toggle.js
+++ b/assets/scripts/font-toggle.js
@@ -58,6 +58,8 @@
     // duplicating the hiding rule in CSS.
     var label = button.querySelector(".dyslexia-toggle-label");
     if (!label || !window.matchMedia) return;
+    // Breakpoint matches the .dyslexia-toggle @media rule in main.css.
+    // Keep both values in sync if the responsive threshold changes.
     var mq = window.matchMedia("(max-width: 700px)");
     function sync() {
       label.classList.toggle("visually-hidden", mq.matches);

--- a/assets/scripts/funnel-experiment.js
+++ b/assets/scripts/funnel-experiment.js
@@ -415,7 +415,10 @@ function ensureLiveRegion() {
   const host = document.getElementById("quarto-document-content") || document.body;
   if (!host) return null;
   feLiveRegion = document.createElement("div");
-  feLiveRegion.className = "fe-sr-live";
+  // fe-sr-live is the semantic identifier (discoverable in DevTools /
+  // future diagnostic styles); visually-hidden provides the off-screen
+  // positioning defined once in main.css.
+  feLiveRegion.className = "fe-sr-live visually-hidden";
   feLiveRegion.setAttribute("role", "status");
   feLiveRegion.setAttribute("aria-live", "polite");
   feLiveRegion.setAttribute("aria-atomic", "true");

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -47,10 +47,20 @@
    but not shown visually. Used for:
    - Persistent live regions (announced state updates)
    - Icon-only button labels (preserved as accessible names)
+
+   Bootstrap 5 (shipped via Cosmo) also defines .visually-hidden, with
+   !important on every property. For the shared properties Bootstrap's
+   rule wins the cascade — in practice harmless because both patterns
+   produce identical behaviour. Our clip-path: inset(50%) does add
+   value: Bootstrap only declares the deprecated clip: rect(...), so
+   our declaration is what gives modern browsers the supported
+   property. If we ever need to diverge from Bootstrap's semantics on
+   the shared properties, this rule will need !important to win.
+
    Apply by adding the class directly in HTML/JS. For cases where
    visibility is conditional (e.g. viewport-dependent), toggle the class
    from JS via matchMedia rather than duplicating the rule in a media
-   query — the rule lives here, in one place. */
+   query. */
 .visually-hidden {
   position: absolute;
   width: 1px;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -42,6 +42,27 @@
   src: url('../fonts/opendyslexic-bolditalic.woff2') format('woff2');
 }
 
+/* ===== VISUALLY HIDDEN UTILITY ===== */
+/* Standard pattern for content that must be available to screen readers
+   but not shown visually. Used for:
+   - Persistent live regions (announced state updates)
+   - Icon-only button labels (preserved as accessible names)
+   Apply by adding the class directly in HTML/JS. For cases where
+   visibility is conditional (e.g. viewport-dependent), toggle the class
+   from JS via matchMedia rather than duplicating the rule in a media
+   query — the rule lives here, in one place. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ===== SKIP-TO-CONTENT LINK ===== */
 .skip-link {
   position: fixed;
@@ -674,20 +695,10 @@ button:focus,
   color: #333;
 }
 
-/* Persistent visually-hidden live region for screen reader announcements.
-   Kept in the DOM across OJS re-renders so status updates are reliably
-   announced (the visible .fe-status is replaced on each render). */
-.fe-sr-live {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
+/* Persistent live region for screen reader announcements. Kept in the DOM
+   across OJS re-renders so status updates are reliably announced (the
+   visible .fe-status is replaced on each render). Hiding styles come from
+   the .visually-hidden utility class applied in funnel-experiment.js. */
 
 /* Comparison grid (2×2 charts) */
 .fe-comparison-grid {
@@ -821,17 +832,9 @@ button:focus,
   .dyslexia-toggle .dyslexia-toggle-icon {
     margin-right: 0;
   }
-  .dyslexia-toggle .dyslexia-toggle-label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
+  /* On narrow viewports the toggle collapses to icon-only. font-toggle.js
+     adds the .visually-hidden class to .dyslexia-toggle-label via
+     matchMedia so the label stays announced by screen readers. */
 }
 
 @media print {


### PR DESCRIPTION
## Summary

- Adds a single canonical `.visually-hidden` utility class to `main.css`, using `clip-path: inset(50%)` instead of the deprecated `clip: rect(...)`.
- Removes the two duplicated hiding rules that previously existed on `.fe-sr-live` and the narrow-viewport `.dyslexia-toggle-label`.
- Wires the utility at its two application sites:
  - `funnel-experiment.js` now adds `visually-hidden` alongside `fe-sr-live` when creating the live region.
  - `font-toggle.js` uses `matchMedia` to toggle `visually-hidden` on the dyslexia label at the 700px breakpoint. Plain CSS lacks media-query-scoped class composition, so the conditional case lives in JS — the rule itself stays in CSS, applied once.

## Why

Issue #179: the project had two copies of the visually-hidden pattern, both using the deprecated `clip` property. Unifying them into one utility cuts the duplication and future-proofs against `clip` removal from browsers.

No user-visible change — purely an internal refactor.

Closes #179.

## Test plan

- [ ] `grep -rn "clip: rect" assets/` returns no matches.
- [ ] `quarto preview` Day 3 chapter 11 (or any page) and confirm:
  - [ ] **Wide viewport (>700px):** the Dyslexia font toggle shows "Aa Dyslexia font" in full.
  - [ ] **Narrow viewport (≤700px):** resize the window below 700px — the label collapses to icon-only, but the button's accessible name still includes "Dyslexia font" (inspect via DevTools or VoiceOver).
  - [ ] **Live resize across the breakpoint:** label hides and shows correctly without a page refresh (confirms `matchMedia` listener is wired).
  - [ ] **Funnel experiment (Day 3 ch. 11 or 12):** click "Next Stage" — the aria-live announcement still fires (confirms the live region is still hidden off-screen but accessible to screen readers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)