### PR TITLE
Fix CI warnings: renv cache path + Node 24 opt-in

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -14,6 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Opt r-lib/actions into Node 24 ahead of the Sept 2026 Node 20 removal.
+# Remove once r-lib publishes a v3 tag that runs on Node 24 natively.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   pa11y:
     runs-on: ubuntu-latest
@@ -70,7 +75,7 @@ jobs:
     - name: Cache R packages
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       with:
-        path: ~/.local/share/renv
+        path: ~/.cache/R/renv
         key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}
         restore-keys: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,11 @@ on:
       - main
   workflow_dispatch:
 
+# Opt r-lib/actions into Node 24 ahead of the Sept 2026 Node 20 removal.
+# Remove once r-lib publishes a v3 tag that runs on Node 24 natively.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test-js:
     runs-on: ubuntu-latest
@@ -86,7 +91,7 @@ jobs:
     - name: Cache R packages
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       with:
-        path: ~/.local/share/renv
+        path: ~/.cache/R/renv
         key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}
         restore-keys: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-
 


### PR DESCRIPTION
## Summary

Addresses two warnings that fired on both the \`pa11y\` workflow (added in #183) and \`deploy.yml\` — same patterns in both files since the R/Quarto steps were copy-pasted.

### 1. renv cache path was wrong

\`path: ~/.local/share/renv\` is XDG-data location. renv's actual Linux cache is at \`~/.cache/R/renv\`, so actions/cache was silently finding nothing to save on every run. Every CI job was re-downloading all R packages. Fix shrinks subsequent runs materially.

Warning text:
> Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.

### 2. r-lib/actions runs on Node 20

The pinned \`v2\` SHA (current tip) still uses Node 20, which GitHub is removing in September 2026 with a forced Node 24 cutover in June. Added \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` as a workflow-level env var in both workflows — the documented opt-in path. Comment marks it for removal once r-lib publishes a Node-24-native v3.

## Test plan

- [ ] Accessibility workflow runs on this PR, warnings no longer appear
- [ ] pa11y-ci still passes 22/22 URLs (the actual checks aren't affected)
- [ ] After merge: first push to main will hit the cache-miss path; second push should pick up the cached packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)