### PR TITLE
Fix broken workbook.html links in Days 1–2 (#137)

### DIFF
--- a/content/days/day-01/03-statistics.qmd
+++ b/content/days/day-01/03-statistics.qmd
@@ -144,7 +144,7 @@ a little arithmetic. But there was nothing about where the simple formula came f
 the large majority of processes, that same formula wouldn’t even be appropriate!
 
 So let’s shed some light on this second paradox. This is a quote from my brief discussion on the sixth of
-Deming’s famous 14 Points for Management: “Institute training” that you will see on Day 4 page 26 *[[WB 66]](workbook.html#sec-page66)*:
+Deming’s famous 14 Points for Management: “Institute training” that you will see on Day 4 page 26 *[WB 66]*:
 
 >In Deming’s terminology, the purpose of ‘training’ is the acquisition of specific skills for specific
 tasks. Training is thus narrowly defined and finite in scale and scope. In contrast, as we shall see

--- a/content/days/day-01/07-quality-theory.qmd
+++ b/content/days/day-01/07-quality-theory.qmd
@@ -23,7 +23,7 @@ The second mention was in a phrase that I had heard from him time and time again
 
 <span class=deming_quote>“Quality is made at the top.”</span>
 
-<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 1-a which follows is also (somewhat unsurprisingly!) on [Workbook page 1](workbook.html).</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">Pause for Thought 1-a which follows is also (somewhat unsurprisingly!) on Workbook page 1.</div>
 
 <div class="neave_note" role="note" aria-label="Author's note">The red box indicates there will now be a Pause for Thought or Activity which is immediately followed by
 some relevant commentary. My commentary will be in the subsequent shaded red box. So always try to
@@ -68,7 +68,7 @@ And then, as a case in point, Dr Deming’s third and final mention of “qualit
 
 ><span class=deming_quote>“Sure we want good results. But if you manage by results, quality goes down, morale goes down.”</span>
 
-<div class="workbook_callout" role="note" aria-label="Workbook reference">The following two Pauses for Thought are also on [Workbook page 2](workbook.html#sec-page2).</div>
+<div class="workbook_callout" role="note" aria-label="Workbook reference">The following two Pauses for Thought are also on Workbook page 2.</div>
 
 <div class="neave_note" role="note" aria-label="Author's note">Unlike a red box, a green box indicates an Activity or Pause for Thought with no associated box of commentary.</div>
 

--- a/content/days/day-01/13-major-activity.qmd
+++ b/content/days/day-01/13-major-activity.qmd
@@ -5,7 +5,7 @@ execute:
 ---
   
 <div class="workbook_callout" role="note" aria-label="Workbook reference">
-Major Activity 1-f (pages 42-44) is also on [Workbook pages 5-7](workbook.html#sec-page5).
+Major Activity 1-f (pages 42-44) is also on Workbook pages 5-7.
 </div>
 
 To complete this opening day of the course, take a few minutes to imagine yourself in each of the following

--- a/content/days/day-02/08-major-activity.qmd
+++ b/content/days/day-02/08-major-activity.qmd
@@ -4,7 +4,7 @@ execute:
   echo: false
 ---
 <div class="workbook_callout" role="note" aria-label="Workbook reference">
-Major Activity 2-h (pages 38-41) is also on [Workbook pages 26-29](workbook.html#sec-page5).
+Major Activity 2-h (pages 38-41) is also on Workbook pages 26-29.
 </div>
 
 Hopefully, you now have quite a long list of notes on learning-points from today’s Red Beads Experiments, including some from Chapter 6 of *DemDim*.


### PR DESCRIPTION
## Summary

- Removes five broken `workbook.html` links across Days 1–2 (the page doesn't exist in this edition — visitors clicking them hit 404)
- Converts each link to plain-text form (e.g. `[Workbook page 1](workbook.html)` → `Workbook page 1`), matching the convention used by the other ~70 non-clickable workbook callouts throughout the book
- Leaves the broader editorial question — what to do with those ~70 non-clickable "also on Workbook page N" mentions — deliberately out of scope; that's tracked in #195 (policy decision) and #196 (implementation, blocked on #195)

Closes #137.

## Files touched

- `content/days/day-01/03-statistics.qmd` — `[WB 66](workbook.html#sec-page66)` in body prose
- `content/days/day-01/07-quality-theory.qmd` — two links in `workbook_callout` divs
- `content/days/day-01/13-major-activity.qmd` — one link in a `workbook_callout` div
- `content/days/day-02/08-major-activity.qmd` — one link in a `workbook_callout` div

## Test plan

- [x] `grep -rn "workbook.html" content/` returns zero matches
- [x] `quarto render` completes with exit 0 and no broken-link warnings
- [ ] Spot-check the four pages in the rendered book — callout text still reads naturally, no orphaned brackets or dangling punctuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)