### PR TITLE
Cache Quarto freeze outputs in CI to speed up render

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -94,6 +94,15 @@ jobs:
     - name: Install npm dependencies
       run: npm ci
 
+    - name: Cache Quarto freeze outputs
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: _freeze
+        key: ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-
+          ${{ runner.os }}-freeze-
+
     - name: Build Quarto book
       run: quarto render
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,15 @@ jobs:
     - name: Run R unit tests
       run: Rscript -e 'testthat::test_dir("tests/testthat")'
 
+    - name: Cache Quarto freeze outputs
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: _freeze
+        key: ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-
+          ${{ runner.os }}-freeze-
+
     - name: Build Quarto book
       run: quarto render
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ upload.sh
 
 _book/
 
+_freeze/
+
 node_modules/
 
 issues/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,4 +1,3 @@
-echo: false
 lang: en
 
 project:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,10 +6,11 @@ project:
   resources:
     - "assets/fonts/**"
 
-execute: 
+execute:
   echo: false
   warning: false
   message: false
+  freeze: auto
 
 book:
   title: "12 Days to Deming"


### PR DESCRIPTION
## Summary

Enables Quarto's `freeze: auto` and caches the resulting `_freeze/` directory in both CI workflows, so R chunks don't re-execute from scratch on every run.

## Why

The Accessibility CI currently takes ~7 minutes per PR. Timing breakdown from the last main build:

| Step | Duration |
|------|----------|
| Setup (R, system deps, Pandoc) | ~53s |
| Existing caches (Quarto binary, R pkgs, npm) — all hits | ~7s |
| **`quarto render`** | **4m 59s** |
| Start server + pa11y-ci | ~46s |

The existing cache layers cover *installs*, but nothing covers render *execution*. With 76 R chunks across 19 `.qmd` files (ggplot + DiagrammeR heavy), re-running them every build is where the time goes.

## What changed

1. `_quarto.yml`: add `freeze: auto` under `execute:`. Chunks only re-execute when their source changes; otherwise outputs are reused from `_freeze/`.
2. `.github/workflows/accessibility.yml` + `deploy.yml`: add an `actions/cache` step for `_freeze/`. Cache key hashes `renv.lock` with a per-commit SHA; `restore-keys` fall back to the most recent cache so prose-only PRs reuse the previous blob whole.
3. `.gitignore`: exclude `_freeze/` from version control (cache-only, not committed).

### Cache-key design

```
key:          ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-${{ github.sha }}
restore-keys: ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-
              ${{ runner.os }}-freeze-
```

- Per-SHA key ensures **every run writes a fresh cache** (GH Actions caches are immutable by key — reusing a key means only the first writer populates it)
- First `restore-keys` line keeps the cache hot across commits whenever `renv.lock` is unchanged
- Second line is a safety net for R-package upgrades (partial reuse > no reuse)

## Expected impact

- **First run after merge**: unchanged (~7m — cache-populating)
- **Subsequent prose-only PRs**: ~2–3 minutes (skips most R execution)
- **PRs that touch R chunks**: partial speedup (only changed chunks re-run)
- **`renv.lock` bumps**: one slow run to refill the cache

## Local verification

- Cold render: existing ~5 min behaviour retained when `_freeze/` is absent
- Warm render (with populated `_freeze/`): **1m 39s** on my machine

## Test plan

- [ ] First CI run populates `_freeze/` cache (verify in Actions UI: cache step shows \"Cache saved with key …\")
- [ ] A follow-up prose-only push reuses the cache (verify: \"Cache restored from key …\") and drops total run time by several minutes
- [ ] `deploy.yml` still produces a valid `_book/` that passes the existing smoke test
- [ ] `quarto render` locally still works after `rm -rf _freeze` (cold path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)