### PR TITLE
Final link-check sweep: fix 5 broken Day 1 internal links (#139)

### DIFF
--- a/content/days/day-01/03-statistics.qmd
+++ b/content/days/day-01/03-statistics.qmd
@@ -214,7 +214,7 @@ Deming Alliance’s website via the following link:
 
 And lastly, if you are *really* keen to have a comprehensive introduction to control charts—going well beyond
 what is necessary for this course—there is the fairly substantial section of “Optional Extras” described at
-the top of [page 8](index.qmd#para-page8) in the “Welcome” section. This optional material contains a variety of topics, all more or
+the top of [page 8](../../../index.qmd#para-page8) in the “Welcome” section. This optional material contains a variety of topics, all more or
 less connected with control charting. But I must emphasise that both this extra material and the Springboard article really are “optional extras”—take them or leave them as you prefer. However, if you decide to
 take them, please don’t count them as being within the recommended 12-day timeframe!
 

--- a/content/days/day-01/04-resources.qmd
+++ b/content/days/day-01/04-resources.qmd
@@ -10,7 +10,7 @@ be helpful in your learning about the more general main themes and content of th
 
 ## The Deming Dimension {#sec-page11}
 
-There is some detailed information about *The Deming Dimension* on [pages 12–13](index.qmd#sec-page12) of the Welcome section
+There is some detailed information about *The Deming Dimension* on [pages 12–13](../../../index.qmd#sec-page12) of the Welcome section
 in the “A. PLEASE START HERE” file.
 
 For brevity I shall henceforth refer to *The Deming Dimension* simply as *DemDim* (as do many of the people

--- a/content/days/day-01/05-activities.qmd
+++ b/content/days/day-01/05-activities.qmd
@@ -26,7 +26,7 @@ my seminars. During the first day of my most usual three-day seminar I would ask
 On the second day there was still plenty for me to do, although now there were increasing amounts of time
 spent on delegates’ discussions and feedback. But on the third day I only contributed about an hour or so
 to the proceedings. The morning was mostly taken up by delegate-led sessions on topics such as the
-three in “The New Climate” (see [page 18](#sec-page18)), to be studied here on [Day 8](day_8.html). Often the delegates were preparing
+three in “The New Climate” (see [page 18](#sec-page18)), to be studied here on [Day 8](../day-08/01-introduction.qmd). Often the delegates were preparing
 these sessions in small groups until late the previous evening: and it was not unknown for me to find the
 early risers doing further work on them before the final day of the seminar commenced. And then, after my
 “hour or so”, the afternoon would be spent with us all involved in discussing topics on which the delegates

--- a/content/days/day-01/07-quality-theory.qmd
+++ b/content/days/day-01/07-quality-theory.qmd
@@ -113,7 +113,7 @@ Why do you think that the word “Quality” might have provoked such a negative
 viewof thought_1c = Inputs.textarea({label: "Why might the word quality provoke a negative reaction?", placeholder: "Type your comments here.", rows: 10})
 ```
 
-<div class=activity_afterthought>(For brief discussion see [Appendix page 6](appendix.html#sec-page6).)</div>
+<div class=activity_afterthought>(For brief discussion see [Appendix page 6](../../appendix/01-day-1.qmd#sec-page6).)</div>
 </div>
 :::
 
@@ -148,7 +148,7 @@ he saw it, here is just part of a sentence from his 1960 book, *Sample Design in
 
 And this use of the word does not just apply to statisticians! In Deming’s mind, the very *purpose* of theory
 is to help guide better *practice*. And if a theory does not do that then it’s not good theory and it needs
-modifying or even abandoning (c.f. the Deming Cycle on [Day 11](day_11.html)).
+modifying or even abandoning (c.f. the Deming Cycle on [Day 11](../day-11/01-introduction.qmd)).
 
 Dr Deming’s opening words in one of the many four-day seminars at which I was present summarised it
 pretty well. He rose slowly to his feet, smiled gently at the 600-strong audience, and said:


### PR DESCRIPTION
## Summary

- Runs the final link-check sweep required by #139 after the inter-day reference wiring (#200, #201, day-09 through day-12 series) landed.
- Fixes 5 pre-migration artifacts in Day 1 where bare relative paths (\`index.qmd\`, \`appendix.html\`, \`day_8.html\`, \`day_11.html\`) were resolving against the source file's directory, producing 404s for \`content/days/day-01/index.qmd\` etc.
- Triages the remaining findings into two follow-up issues.

## Link-check results

**Tool**: \`npx linkinator http://localhost:8765/ --recurse\` against a freshly-rendered \`_book/\` served via \`npm run a11y:serve\`. Also cross-checked with \`quarto render\` stderr for \`Unable to resolve link target\` warnings.

| Phase | Quarto warnings | linkinator internal | linkinator external |
|---|---|---|---|
| Before | 1 (from Day 1) | 5 broken | 6 broken (3 false positives) |
| After  | 0               | 0 broken       | 6 broken (same — see #239) |

## Fixes in this PR

| File | Before | After |
|---|---|---|
| \`content/days/day-01/03-statistics.qmd:217\` | \`index.qmd#para-page8\` | \`../../../index.qmd#para-page8\` |
| \`content/days/day-01/04-resources.qmd:13\`   | \`index.qmd#sec-page12\`  | \`../../../index.qmd#sec-page12\` |
| \`content/days/day-01/05-activities.qmd:29\`  | \`day_8.html\`             | \`../day-08/01-introduction.qmd\` |
| \`content/days/day-01/07-quality-theory.qmd:116\` | \`appendix.html#sec-page6\` | \`../../appendix/01-day-1.qmd#sec-page6\` |
| \`content/days/day-01/07-quality-theory.qmd:151\` | \`day_11.html\`           | \`../day-11/01-introduction.qmd\` |

The inter-day wiring PRs didn't surface these because the audit pattern was \`Day N page M\`, not bare filenames.

## Spot-check of surviving plain-text refs

Per the issue's acceptance criterion. 121 plain-text \`Day N page M\` occurrences survive in content/. Random-sample check of 2 per category:

- **Inline prose** (82): \`(Day 3 pages 51 and 55 *[WB 43 and 45]* respectively)\` — reads sensibly as plain prose; leave.
- **Page-range prose** (22): \`see Day 2 pages 43–44\` — inconsistent with single-page wiring convention → **#240**.
- **H2 annotations** (13): \`## Disease 1. Lack of constancy *(Day 5 pages 18–19)* {#sec-page28}\` — previously flagged in [#199's comment](https://github.com/lddurbin/twelve_days_to_deming/issues/199#issuecomment-4275555200) → **#240**.
- **'Return to' annotations** (4): \`*(Return to Day 11 pages 18–21.)*\` — same convention gap → **#240**.

## Cross-category edge cases triaged

- **#239** — External link rot: \`deming.org.uk\` (4 refs) and \`rqoq.org.nz\` (1 ref) return HTTP 000. Needs editorial decision.
- **#240** — Page-range and H2-annotation inter-day references, complementing #199.

## Note on #199

The audit CSV (\`workflow/inter-day-refs.csv\`) exists but its \`decision\` column is empty for all 241 rows. The execution PRs shipped without committing editorial decisions; the convention applied (link single pages, leave ranges/annotations plain) is implicit in the diffs. #240 captures the rate-limited follow-up. Not fixing #199 in this PR since that's paperwork, not a link defect.

## Test plan

- [x] \`quarto render\` — clean (0 cross-ref warnings)
- [x] \`npx linkinator http://localhost:8765/ --recurse --skip "^https?://(?!localhost)|mailto:|^#"\` — 346 OK, 0 BROKEN
- [x] curl each of the 5 fixed links' targets — all resolve
- [x] Random-sample spot-check of plain-text survivors recorded above

🤖 Generated with [Claude Code](https://claude.com/claude-code)