### PR TITLE
Close out #208: drop residual appendix Workbook mention

### DIFF
--- a/content/appendix/00-welcome.qmd
+++ b/content/appendix/00-welcome.qmd
@@ -26,4 +26,4 @@ As mentioned near the end of the “Welcome” section, this is the reference li
 
 **Before Day 12.** For a little equipment and one or more copies or enlargements: see [Day 11 page 36](../days/day-11/08-coda.qmd#sec-page36).
 
-Finally, if and when you decide to venture into the **Optional Extras** but without printing that file or the Workbook, there are just two pages in both Parts A and B which you will need to print out before studying those first two parts. They are pages 6 and 7 in Part A and pages 24 and 25 in Part B.
+Finally, if and when you decide to venture into the **Optional Extras** but without printing that file, there are just two pages in both Parts A and B which you will need to print out before studying those first two parts. They are pages 6 and 7 in Part A and pages 24 and 25 in Part B.

--- a/docs/deviations-from-source.md
+++ b/docs/deviations-from-source.md
@@ -65,15 +65,6 @@ Entries are listed newest-first.
 - **Landed in** — PR [#214](https://github.com/lddurbin/twelve_days_to_deming/pull/214) (closes #209, #210).
 - **Related** — [#213](https://github.com/lddurbin/twelve_days_to_deming/issues/213) tracks the still-pending decision on inline `[WB NNN]` cross-reference suffixes; [#212](https://github.com/lddurbin/twelve_days_to_deming/issues/212) covers the `index.qmd` front-matter Workbook prose still to be addressed.
 
-## 2026-04-21 — Remove the appendix Welcome Workbook passage
-
-- **What** — Remove the standalone Welcome Workbook passage from the appendix, which introduced the printed Workbook as a companion artefact to the course.
-- **Where** — `content/appendix/` (the Welcome Workbook appendix entry).
-- **Source reference** — NZOQ appendix material introducing the printed Workbook and how to use it alongside the course.
-- **Why** — The Workbook is not part of this site's delivery model; the passage exists solely to frame a printed artefact that the site has replaced with in-page interaction. Leaving it in would mislead readers about what the site provides.
-- **Decided in** — [#185 decision comment](https://github.com/lddurbin/twelve_days_to_deming/issues/185#issuecomment-4286006129) (D2). Neave's framing is pedagogically significant, so the removal is logged here rather than folded silently into a cleanup PR.
-- **Landed in** — *Pending — tracked in [#208](https://github.com/lddurbin/twelve_days_to_deming/issues/208).*
-
 ## 2026-04-21 — Remove inline "see Workbook p. N" page-reference call-outs
 
 - **What** — Delete the `.workbook_callout` divs and their inline "see Workbook p. N" page-reference anchors throughout day chapters. Remove the associated CSS class and any manifest fields that validated their presence.


### PR DESCRIPTION
## Summary

- #208 was scoped against a "multi-page Welcome Workbook passage" in `content/appendix/00-welcome.qmd`. That passage never existed in this file; the pre-sweep version was always just the *Recommended Out-of-Hours Preparation* checklist. The multi-page passage the issue has in mind lives in `index.qmd` (front matter) and is tracked by **#212**.
- Dropped the one residual "or the Workbook" phrase at `content/appendix/00-welcome.qmd:29` so the appendix is fully clean of printed-Workbook references.
- Removed the misframed entry in `docs/deviations-from-source.md` that claimed a standalone "Welcome Workbook appendix passage" was pending removal — there was no such passage to record.

Closes #208. Front-matter Workbook-system passage remains scoped to #212.

## Test plan

- [ ] `quarto render content/appendix/00-welcome.qmd` renders cleanly (✓ verified locally).
- [ ] No remaining "Workbook" references in `content/appendix/` (✓ `grep` confirms).
- [ ] Claude review check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)