### PR TITLE
Add 'About this Edition' foreword and reference pages (#194)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,6 +20,7 @@ book:
     collapse-level: 1
   
   chapters:
+    - about-this-edition.qmd
     - welcome.qmd
     - index.qmd
     - part: "Day 1: The Overture"
@@ -141,6 +142,9 @@ book:
         - content/days/day-12/06-activity-12d.qmd
         - content/days/day-12/07-major-activity-12e.qmd
         - content/days/day-12/08-epilogue.qmd
+
+    - accessibility.qmd
+    - changes-from-source.qmd
 
   appendices:
     - content/appendix/00-welcome.qmd

--- a/about-this-edition.qmd
+++ b/about-this-edition.qmd
@@ -1,0 +1,50 @@
+---
+title: "About this Edition"
+execute:
+  echo: false
+---
+
+
+## A short introduction
+
+The 12 Days to Deming Active Learning Course was created by Dr Henry Neave and first launched in 2020. The course has been adapted for the web by me, Lee Durbin, and first launched in 2026.
+
+Dr Henry Neave created 12 Days to Deming to take you on a journey to deeply understand what Dr W. Edwards Deming (1900–1993) taught.
+
+Dr Deming is famous for his work in Japan in the 1950s and in the West from the early 1980s; I first heard about him during an Agile training course when he was mentioned alongside the Toyota Production System. It wasn't until five years later that I encountered him again, when I read [Cedric Chen's "Becoming Data Driven, From First Principles"](https://commoncog.com/becoming-data-driven-first-principles/) which completely changed my perspective on my work as a data analyst.
+
+Wishing to learn more about Dr Deming and his teaching, I participated in a study group hosted by the [Geelong Quality Council](https://www.gqc.org.au/12-days-to-deming) in early 2024. This was my introduction to 12 Days to Deming, and gave me an opportunity to review, discuss, and share my insights about the material. Dr Jackie Graham, who worked closely with Dr Deming, mentored the study group - and, as of the time of writing, continues to do so.
+
+## Why this edition exists
+
+After completing the 12 Days to Deming course via the study group, I reflected on my learning experiences and thought about how it might be improved for future students.
+
+The full course material is available as free PDF downloads from several sources, including the [New Zealand Organisation for Quality (NZOQ)](https://www.nzoq.org.nz/12-days-to-deming) and [SPC Press](https://www.spcpress.com/12-Days-To-Deming.php). These materials were designed to be printed, which may place accessibility limitations on learners with specific needs. My primary motivation for creating this website is to improve the accessibility of the learning material, and accessibility is a first-class concern in this interactive version.
+
+The [accessibility page](accessibility.qmd) catalogues the features currently in place — skip-to-content links, an OpenDyslexic font toggle, visible focus indicators, ARIA labelling, non-colour status cues, reduced-motion support, and print-safe styling — and lists the improvements still to come. If you encounter an accessibility issue, please email me directly at [hello@leedurbin.co.nz](mailto:hello@leedurbin.co.nz) and I'll be happy to explore how to improve the site.
+
+## What has changed, and what hasn't
+
+In adapting 12 Days to Deming for the web, several adaptations were made. 
+
+This interactive online version preserves Dr Neave's original content exactly as he wrote it, and no major changes have been made to his teachings, examples, or explanations. The changes are to how the course is delivered, not what it teaches — Dr Neave's words, examples, and sequencing are intact.
+
+The most visible change is that the printable Workbook — Dr Neave's original response-capture document — has been replaced with in-page text boxes and a per-page notes download. A full summary of deliberate departures from the source text is on the [changes from the source](changes-from-source.qmd) page.
+
+## Thanks
+
+There are a number of individuals I'd like to thank for contributing directly or indirectly to the existence of this edition.
+
+First and foremost I must thank Henry Neave for creating the course in the first place. As you'll read in his [background to the course](welcome.html#days-to-deming-some-background), Dr Neave worked on these materials for some 20 years before releasing them to the world. There are few who have worked so tirelessly to promote and explain Dr Deming's teaching, and for that I'm indebted to him.
+
+I'd also like to thank Richard Hamilton, Jenny Perks, Dr Jackie Graham, and all those (past and present) who support the 12 Days to Deming Study Group. Richard in particular has been very supportive of my efforts here, and provided vital early-stage feedback.
+
+Cedric Chen's essay, "Becoming Data Driven, From First Principles", was the catalyst that prompted me to immerse myself in Deming's philosophy. It also transformed the way I think about the work I do as a data analyst, and so I'm grateful to Cedric for his writing and his continued leadership in this space.
+
+## Contributing and reporting issues
+
+The site lives on GitHub at [github.com/lddurbin/twelve_days_to_deming](https://github.com/lddurbin/twelve_days_to_deming) and I welcome contributions of all sizes. If you spot a typo, a broken link, a cross-reference that doesn't resolve, or anything else that looks wrong, please [open an issue](https://github.com/lddurbin/twelve_days_to_deming/issues/new) or a pull request. Suggestions for new activities, improvements to existing ones, or additional accessibility features are just as valuable as bug reports — if you're not sure whether something is worth raising, raise it anyway. I'd rather hear about small issues than miss them.
+
+---
+
+*With that, over to Henry.*

--- a/about-this-edition.qmd
+++ b/about-this-edition.qmd
@@ -35,7 +35,7 @@ The most visible change is that the printable Workbook — Dr Neave's original r
 
 There are a number of individuals I'd like to thank for contributing directly or indirectly to the existence of this edition.
 
-First and foremost I must thank Henry Neave for creating the course in the first place. As you'll read in his [background to the course](welcome.html#days-to-deming-some-background), Dr Neave worked on these materials for some 20 years before releasing them to the world. There are few who have worked so tirelessly to promote and explain Dr Deming's teaching, and for that I'm indebted to him.
+First and foremost I must thank Henry Neave for creating the course in the first place. As you'll read in his [background to the course](welcome.qmd#days-to-deming-some-background), Dr Neave worked on these materials for some 20 years before releasing them to the world. There are few who have worked so tirelessly to promote and explain Dr Deming's teaching, and for that I'm indebted to him.
 
 I'd also like to thank Richard Hamilton, Jenny Perks, Dr Jackie Graham, and all those (past and present) who support the 12 Days to Deming Study Group. Richard in particular has been very supportive of my efforts here, and provided vital early-stage feedback.
 

--- a/accessibility.qmd
+++ b/accessibility.qmd
@@ -1,0 +1,33 @@
+---
+title: "Accessibility"
+execute:
+  echo: false
+---
+
+Accessibility is a first-class concern in this web edition. The features below are what's in place today; the list will grow as further improvements land.
+
+If you encounter an accessibility issue — something that doesn't work with your keyboard, screen reader, or preferred display settings — please email me at [hello@leedurbin.co.nz](mailto:hello@leedurbin.co.nz) or [open an issue on GitHub](https://github.com/lddurbin/twelve_days_to_deming/issues). I treat accessibility reports as priority bugs.
+
+## Current features
+
+**Skip-to-content link.** Keyboard and screen-reader users can bypass the sidebar on every page. The link appears as the first focusable element on page load.
+
+**OpenDyslexic font toggle.** A fixed button in the bottom-right of every page switches body and heading text to the [OpenDyslexic](https://opendyslexic.org/) typeface, which some readers with dyslexia find easier to parse. The preference persists across pages.
+
+**Visible focus indicators.** Keyboard focus is clearly outlined on all interactive controls (links, buttons, text inputs, toggles). Mouse users are unaffected.
+
+**ARIA labelling.** Interactive elements, data tables, and input widgets expose accessible names to assistive technology. This includes the site search, the activity text inputs, and the chart-embedded controls on Days 2, 3, and 6.
+
+**Non-colour status indicators.** Where the course uses colour to convey state — for example, the four phases of the funnel experiment on Day 3 — shape and text are used alongside colour, meeting [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html).
+
+**Reduced-motion support.** Animated transitions respect the [`prefers-reduced-motion: reduce`](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html) media query. If your operating system or browser requests reduced motion, the site complies.
+
+**Print-safe styling.** Decorative controls and colour overrides are suppressed in print media, so hard-copy notes and PDF exports render cleanly.
+
+## Automated checks
+
+Every pull request to the repository runs [pa11y](https://pa11y.org/) against the rendered site. The build fails if any WCAG 2.1 AA issue is detected, so the main branch is kept passing at all times.
+
+## What's still to come
+
+Planned improvements are tracked on GitHub under the [accessibility label](https://github.com/lddurbin/twelve_days_to_deming/issues?q=is%3Aissue+is%3Aopen+label%3Aaccessibility). Current priorities include long-descriptions for the statistical charts across Days 4–12, a per-chapter text-to-speech control, a light/dark mode toggle, and an estimated reading-time indicator.

--- a/changes-from-source.qmd
+++ b/changes-from-source.qmd
@@ -1,0 +1,39 @@
+---
+title: "Changes from the source"
+execute:
+  echo: false
+---
+
+This web edition transcribes Dr Neave's prose verbatim. Typography, whitespace, and punctuation have been normalised for the web, scanned figures have been re-extracted, and internal cross-references have been turned into hyperlinks — but his words, examples, and sequencing are intact.
+
+There are two areas where the adaptation to the web has made **material** changes to the source. They are listed below, in plain terms, so readers cross-referencing the original PDF know up-front what's different.
+
+## The printed Workbook
+
+Dr Neave's original course came as two documents: the day chapters (what you're reading now) and a **Workbook** — a printable second document with blank writing surfaces for the exercises and activities. The two cross-referenced each other throughout: every Day-chapter page cited a matching Workbook page, and the Workbook provided the space to capture the reader's responses.
+
+This web edition replaces the Workbook with **in-page interactive elements**: text boxes for activity responses, a per-page notes-download button that collects your answers into a single file, and interactive widgets for the experiments on Days 2, 3, and 6. As a result, the Workbook no longer exists as a separate artefact.
+
+That change cascaded into several small edits:
+
+- **Inline "see Workbook p. N" call-outs** throughout the days have been removed, because they pointed at a document that is no longer part of the delivery.
+- **Workbook page-number suffixes** (the `[WB 123]` markers paired with Day-chapter references) have been stripped. The Day-chapter page numbers carry the full navigation intent on their own.
+- **Appendix return-navigation parentheticals** ("Return to Workbook page X / Day Y page Z") have been shortened to just the Day-chapter half.
+- The **front-matter printing and binding guidance** — covering how to print the PDF double-sided, which ring-binders to use, and how to interleave the day chapters with the Workbook — has been removed. None of it applies to a Quarto HTML rendering.
+
+Where a reader response originally prompted "write your answer in the Workbook on page N", it now prompts "write your answer below" and the site captures the response on the page.
+
+## Dead external links
+
+The course text links out to several external sites. Two domains that Dr Neave's materials treat as live resources are no longer online:
+
+- **`deming.org.uk`** — the UK Deming Transformation Forum's Learning Store, which sold books and course materials. The domain no longer resolves; the Forum appears to have wound down. Links to this domain now point at the [2012 Wayback Machine snapshot](https://web.archive.org/web/20120105232234/http://deming.org.uk/) with an inline note that the live site is offline. One book-ordering footnote was de-linked entirely, because pointing readers at a 2012 snapshot to "order the book" would be actively misleading.
+- **`rqoq.org.nz`** — a PDF-hosting mirror site, the Royal Quality Organisation of Queensland. The domain no longer resolves and was never archived by the Wayback Machine. References have been de-linked with an editorial note that the site is no longer available.
+
+All other external links in the course — to Deming-related organisations, YouTube videos, books, and academic resources — were verified and remain live at the time of writing.
+
+## The full technical log
+
+Every material departure from the source is recorded, with PR and commit references, in the [deviations log on GitHub](https://github.com/lddurbin/twelve_days_to_deming/blob/main/docs/deviations-from-source.md). That log is intended for contributors and for readers cross-referencing the source PDFs who want to know exactly where and when each change landed.
+
+If you spot something that you think is a material departure and isn't documented here or in the technical log, please [open an issue](https://github.com/lddurbin/twelve_days_to_deming/issues). Invisible changes are the failure mode this page is here to prevent.


### PR DESCRIPTION
## Summary

- New front-matter `about-this-edition.qmd` wired as the first chapter before `welcome.qmd`, written in the adaptor's voice (first person) so that Lee's framing and Henry's preface are clearly distinct.
- New `accessibility.qmd` catalogues the current accessibility features (skip-link, OpenDyslexic toggle, ARIA labelling, non-colour status cues, reduced-motion support, print-safe styling, pa11y CI gating) and links to the accessibility-label issue filter for planned work.
- New `changes-from-source.qmd` gives a reader-friendly narrative of the two material departures from Neave's source (the Workbook removal + digital-first response capture, and the dead external links), with a pointer to the technical `docs/deviations-from-source.md` for contributors.

Both reference pages sit after Day 12's epilogue in the `chapters:` block rather than under `appendices:` — Quarto runs out of appendix letters past Z and emits "Appendix &nbsp;— …" labels, which keeping them as plain-titled chapters avoids entirely.

## Why

Closes #194. Post Workbook-removal arc, the front-matter stack now reads cleanly as Henry's voice (welcome → please-start-here). #194 asked for a short foreword that separates "what I changed for the web" from "what Henry wrote", plus supporting reference material for curious readers.

## Test plan

- [x] `quarto render` succeeds for all three new files
- [x] Sidebar reads: *About this Edition* → *Welcome* → *PLEASE START HERE* → *Day 1 …* → *Day 12* → *Accessibility* → *Changes from the source* → appendices
- [x] Rendered `<title>` tags are clean ("Accessibility", "Changes from the source") with no leftover appendix-letter artefacts
- [ ] pa11y passes in CI
- [ ] Links out of `about-this-edition.qmd` resolve (→ `accessibility.qmd`, → `changes-from-source.qmd`, → `welcome.html#days-to-deming-some-background`, external Commoncog/Geelong/NZOQ/SPC Press, GitHub issues URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)