### PR TITLE
Extend validation scripts to cover appendix content (#186)

### DIFF
--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -3,11 +3,14 @@
 # check-structure.sh — Structural inventory checker for QMD chapter completeness
 #
 # Usage: ./scripts/check-structure.sh <day-number>
+#        ./scripts/check-structure.sh --appendix <slug>
 #   e.g. ./scripts/check-structure.sh 3
+#        ./scripts/check-structure.sh --appendix contributions-balaji-reddie
 #
-# Compares each QMD chapter against a per-day manifest and reports PASS/FAIL
-# per check per chapter. Checks: viewof count, figure existence, section
-# headings, download button.
+# Compares each QMD chapter against a manifest and reports PASS/FAIL per check
+# per chapter. Day manifests cover viewof count, figures, headings, and
+# download button. Appendix manifests can opt out of interactive checks for
+# prose-only content (set `interactive_checks: false`).
 #
 # Requires: ruby (for YAML parsing — ships with macOS)
 # Note: CI (Ubuntu) does not install Ruby by default. If wiring into CI,
@@ -16,7 +19,6 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CONTENT_DIR="$REPO_ROOT/content/days"
 MANIFEST_DIR="$REPO_ROOT/workflow/validation"
 TMPDIR_CLEANUP=""
 
@@ -35,7 +37,10 @@ fi
 
 usage() {
   echo "Usage: $0 <day-number>"
-  echo "  day-number: 1-12"
+  echo "       $0 --appendix <slug>"
+  echo ""
+  echo "  day-number:       1-12 (uses workflow/validation/day-NN-manifest.yml)"
+  echo "  --appendix <slug>: uses workflow/validation/appendix-<slug>-manifest.yml"
   echo ""
   echo "Checks QMD chapters against a structural manifest and reports"
   echo "PASS/FAIL per check per chapter."
@@ -46,9 +51,10 @@ pass() { printf "  ${GREEN}PASS${RESET} %s\n" "$1"; }
 fail() { printf "  ${RED}FAIL${RESET} %s\n" "$1"; }
 warn() { printf "  ${YELLOW}WARN${RESET} %s\n" "$1"; }
 
-# Expand manifest into a flat text format using Ruby, one file per chapter.
-# Each chapter file contains key=value lines, with multi-value fields
-# (figures, headings) on separate ITEM= lines.
+# Expand manifest into a flat text format using Ruby, one file per chapter,
+# plus a top-level `meta` file capturing manifest-wide settings
+# (content_dir, interactive_checks). Multi-value chapter fields
+# (figures, headings) appear as separate ITEM= lines.
 expand_manifest() {
   local manifest="$1"
   local outdir="$2"
@@ -60,11 +66,16 @@ expand_manifest() {
       exit 1
     end
     outdir = ARGV[1]
+    File.open("#{outdir}/meta", "w") do |f|
+      f.puts "CONTENT_DIR=#{data["content_dir"] || ""}"
+      interactive = data.key?("interactive_checks") ? data["interactive_checks"] : true
+      f.puts "INTERACTIVE=#{interactive ? "true" : "false"}"
+    end
     data["chapters"].each_with_index do |ch, i|
       File.open("#{outdir}/ch_#{format("%02d", i)}", "w") do |f|
         f.puts "FILE=#{ch["file"]}"
-        f.puts "VIEWOF=#{ch["viewof_count"]}"
-        f.puts "DOWNLOAD=#{ch["has_download_button"]}"
+        f.puts "VIEWOF=#{ch["viewof_count"] || 0}"
+        f.puts "DOWNLOAD=#{ch.key?("has_download_button") ? ch["has_download_button"] : false}"
         (ch["figures"] || []).each { |fig| f.puts "FIGURE=#{fig}" }
         (ch["headings"] || []).each { |h| f.puts "HEADING=#{h}" }
       end
@@ -94,31 +105,70 @@ extract_headings() {
 # ── Main ──────────────────────────────────────────────────────
 
 main() {
-  local day_num="${1:-}"
-
-  if [[ -z "$day_num" || ! "$day_num" =~ ^[0-9]+$ ]]; then
-    usage
-  fi
-
-  if (( day_num < 1 || day_num > 12 )); then
-    echo "Error: day-number must be between 1 and 12"
-    exit 1
-  fi
-
   if ! command -v ruby &>/dev/null; then
     echo "Error: ruby not found (needed for YAML parsing)"
     exit 1
   fi
 
-  local day_dir
-  day_dir=$(printf "day-%02d" "$day_num")
-  local manifest="$MANIFEST_DIR/${day_dir}-manifest.yml"
-  local qmd_dir="$CONTENT_DIR/$day_dir"
+  # ── Argument parsing ──
+  local mode="" target="" label="" manifest="" qmd_dir=""
+
+  if [[ "${1:-}" == "--appendix" ]]; then
+    mode="appendix"
+    target="${2:-}"
+    if [[ -z "$target" ]]; then
+      echo "Error: --appendix requires a slug (e.g. contributions-balaji-reddie)"
+      usage
+    fi
+    manifest="$MANIFEST_DIR/appendix-${target}-manifest.yml"
+    label="Appendix: $target"
+  elif [[ -n "${1:-}" && "$1" =~ ^[0-9]+$ ]]; then
+    mode="day"
+    target="$1"
+    if (( target < 1 || target > 12 )); then
+      echo "Error: day-number must be between 1 and 12"
+      exit 1
+    fi
+    local day_dir
+    day_dir=$(printf "day-%02d" "$target")
+    manifest="$MANIFEST_DIR/${day_dir}-manifest.yml"
+    qmd_dir="$REPO_ROOT/content/days/$day_dir"
+    label="Day $target"
+  else
+    usage
+  fi
 
   if [[ ! -f "$manifest" ]]; then
     echo "Error: No manifest found at $manifest"
     echo "Create one before running this check."
     exit 1
+  fi
+
+  # Expand manifest into per-chapter temp files
+  TMPDIR_CLEANUP=$(mktemp -d)
+  local tmpdir="$TMPDIR_CLEANUP"
+  trap 'rm -rf "$TMPDIR_CLEANUP"' EXIT
+  expand_manifest "$manifest" "$tmpdir"
+
+  # Read manifest meta (content_dir, interactive_checks)
+  local manifest_content_dir="" interactive_checks="true"
+  while IFS='=' read -r key value; do
+    case "$key" in
+      CONTENT_DIR) manifest_content_dir="$value" ;;
+      INTERACTIVE) interactive_checks="$value" ;;
+    esac
+  done < "$tmpdir/meta"
+
+  # Appendix manifests MUST declare content_dir; day manifests use the
+  # convention-derived path unless they override.
+  if [[ "$mode" == "appendix" ]]; then
+    if [[ -z "$manifest_content_dir" ]]; then
+      echo "Error: appendix manifest must declare content_dir"
+      exit 1
+    fi
+    qmd_dir="$REPO_ROOT/$manifest_content_dir"
+  elif [[ -n "$manifest_content_dir" ]]; then
+    qmd_dir="$REPO_ROOT/$manifest_content_dir"
   fi
 
   if [[ ! -d "$qmd_dir" ]]; then
@@ -128,18 +178,15 @@ main() {
 
   echo "=========================================="
   echo "  Structural Inventory Report"
-  echo "  Day $day_num"
+  echo "  $label"
   echo "=========================================="
   echo ""
   echo "Manifest: $(basename "$manifest")"
-  echo "QMD dir:  $day_dir/"
+  echo "QMD dir:  ${qmd_dir#"$REPO_ROOT/"}/"
+  if [[ "$interactive_checks" != "true" ]]; then
+    echo "Mode:     prose-only (viewof and download-button checks skipped)"
+  fi
   echo ""
-
-  # Expand manifest into per-chapter temp files
-  TMPDIR_CLEANUP=$(mktemp -d)
-  local tmpdir="$TMPDIR_CLEANUP"
-  trap 'rm -rf "$TMPDIR_CLEANUP"' EXIT
-  expand_manifest "$manifest" "$tmpdir"
 
   local total_checks=0
   local total_pass=0
@@ -147,6 +194,7 @@ main() {
   local total_warn=0
 
   for ch_file in "$tmpdir"/ch_*; do
+    [[ -f "$ch_file" ]] || continue
     # Read chapter metadata
     local file="" expected_viewof=0 expected_dl="false"
     local figures="" headings=""
@@ -186,15 +234,17 @@ main() {
     fi
 
     # ── Check 1: viewof count ──
-    local actual_viewof
-    actual_viewof=$(count_viewof "$qmd_path")
-    total_checks=$((total_checks + 1))
-    if [[ "$actual_viewof" -eq "$expected_viewof" ]]; then
-      pass "viewof declarations: $actual_viewof (expected $expected_viewof)"
-      total_pass=$((total_pass + 1))
-    else
-      fail "viewof declarations: $actual_viewof (expected $expected_viewof)"
-      total_fail=$((total_fail + 1))
+    if [[ "$interactive_checks" == "true" ]]; then
+      local actual_viewof
+      actual_viewof=$(count_viewof "$qmd_path")
+      total_checks=$((total_checks + 1))
+      if [[ "$actual_viewof" -eq "$expected_viewof" ]]; then
+        pass "viewof declarations: $actual_viewof (expected $expected_viewof)"
+        total_pass=$((total_pass + 1))
+      else
+        fail "viewof declarations: $actual_viewof (expected $expected_viewof)"
+        total_fail=$((total_fail + 1))
+      fi
     fi
 
     # ── Check 2: figure references ──
@@ -282,23 +332,25 @@ main() {
     fi
 
     # ── Check 4: download button ──
-    total_checks=$((total_checks + 1))
-    if [[ "$expected_dl" == "true" ]]; then
-      if grep -qE 'create(Coop)?DownloadButton' "$qmd_path" 2>/dev/null; then
-        pass "download button: present"
-        total_pass=$((total_pass + 1))
+    if [[ "$interactive_checks" == "true" ]]; then
+      total_checks=$((total_checks + 1))
+      if [[ "$expected_dl" == "true" ]]; then
+        if grep -qE 'create(Coop)?DownloadButton' "$qmd_path" 2>/dev/null; then
+          pass "download button: present"
+          total_pass=$((total_pass + 1))
+        else
+          fail "download button: missing (expected)"
+          total_fail=$((total_fail + 1))
+        fi
       else
-        fail "download button: missing (expected)"
-        total_fail=$((total_fail + 1))
-      fi
-    else
-      if grep -qE 'create(Coop)?DownloadButton' "$qmd_path" 2>/dev/null; then
-        warn "download button: found but not in manifest"
-        total_pass=$((total_pass + 1))
-        total_warn=$((total_warn + 1))
-      else
-        pass "download button: none expected"
-        total_pass=$((total_pass + 1))
+        if grep -qE 'create(Coop)?DownloadButton' "$qmd_path" 2>/dev/null; then
+          warn "download button: found but not in manifest"
+          total_pass=$((total_pass + 1))
+          total_warn=$((total_warn + 1))
+        else
+          pass "download button: none expected"
+          total_pass=$((total_pass + 1))
+        fi
       fi
     fi
 

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -120,6 +120,10 @@ main() {
       echo "Error: --appendix requires a slug (e.g. contributions-balaji-reddie)"
       usage
     fi
+    if [[ ! "$target" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+      echo "Error: slug must contain only letters, digits, hyphens, and underscores"
+      exit 1
+    fi
     manifest="$MANIFEST_DIR/appendix-${target}-manifest.yml"
     label="Appendix: $target"
   elif [[ -n "${1:-}" && "$1" =~ ^[0-9]+$ ]]; then
@@ -147,7 +151,7 @@ main() {
   # Expand manifest into per-chapter temp files
   TMPDIR_CLEANUP=$(mktemp -d)
   local tmpdir="$TMPDIR_CLEANUP"
-  trap 'rm -rf "$TMPDIR_CLEANUP"' EXIT
+  trap 'rm -rf "$TMPDIR_CLEANUP" 2>/dev/null || true' EXIT
   expand_manifest "$manifest" "$tmpdir"
 
   # Read manifest meta (content_dir, interactive_checks)

--- a/scripts/validate-transcription.sh
+++ b/scripts/validate-transcription.sh
@@ -3,13 +3,19 @@
 # validate-transcription.sh — Compare source PDF text against QMD transcriptions
 #
 # Usage: ./scripts/validate-transcription.sh <day-number>
+#        ./scripts/validate-transcription.sh --appendix <slug>
 #   e.g. ./scripts/validate-transcription.sh 3
+#        ./scripts/validate-transcription.sh --appendix contributions-balaji-reddie
 #
 # Requires: pdftotext (brew install poppler)
+#           ruby (YAML parsing for appendix manifests)
 #
-# PDF letter-prefix mapping:
+# Day mode uses the PDF letter-prefix mapping:
 #   D=Day1, E=Day2, F=Day3, G=Day4, H=Day5, I=Day6,
 #   J=Day7, K=Day8, L=Day9, M=Day10, N=Day11, O=Day12
+#
+# Appendix mode reads workflow/validation/appendix-<slug>-manifest.yml
+# for `pdf_file` and `content_dir`.
 
 set -euo pipefail
 
@@ -20,7 +26,8 @@ export LC_ALL=C
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PDF_DIR="$REPO_ROOT/12-Days-to-Deming/PDFs"
-CONTENT_DIR="$REPO_ROOT/content/days"
+MANIFEST_DIR="$REPO_ROOT/workflow/validation"
+TMPDIR_CLEANUP=""
 
 # Map day numbers (1-12) to PDF letter prefixes (D-O)
 # ASCII: D=68, day 1 → offset 0 → D, day 2 → offset 1 → E, etc.
@@ -36,7 +43,10 @@ MIN_PARA_LEN=40
 
 usage() {
   echo "Usage: $0 <day-number>"
-  echo "  day-number: 1-12"
+  echo "       $0 --appendix <slug>"
+  echo ""
+  echo "  day-number:        1-12"
+  echo "  --appendix <slug>: uses workflow/validation/appendix-<slug>-manifest.yml"
   echo ""
   echo "Compares source PDF text against QMD transcriptions and reports"
   echo "potential gaps — paragraphs in the PDF with no close match in the QMD files."
@@ -48,6 +58,26 @@ check_deps() {
     echo "Error: pdftotext not found. Install with: brew install poppler"
     exit 1
   fi
+}
+
+# Read `pdf_file` and `content_dir` from an appendix manifest.
+# Prints two lines: PDF_FILE=... then CONTENT_DIR=...
+read_appendix_manifest() {
+  local manifest="$1"
+  if ! command -v ruby &>/dev/null; then
+    echo "Error: ruby not found (needed for YAML parsing)" >&2
+    exit 1
+  fi
+  ruby -ryaml -e '
+    begin
+      data = YAML.safe_load(File.read(ARGV[0]))
+    rescue => e
+      $stderr.puts "Error parsing manifest #{ARGV[0]}: #{e.message}"
+      exit 1
+    end
+    puts "PDF_FILE=#{data["pdf_file"] || ""}"
+    puts "CONTENT_DIR=#{data["content_dir"] || ""}"
+  ' "$manifest"
 }
 
 # Strip QMD markup to produce plain text
@@ -224,35 +254,69 @@ find_in_qmd() {
 # ── Main ───────────────────────────────────────────────────────
 
 main() {
-  local day_num="${1:-}"
+  check_deps
 
-  if [[ -z "$day_num" || ! "$day_num" =~ ^[0-9]+$ ]]; then
+  # ── Argument parsing ──
+  local pdf_file="" qmd_dir="" label=""
+
+  if [[ "${1:-}" == "--appendix" ]]; then
+    local slug="${2:-}"
+    if [[ -z "$slug" ]]; then
+      echo "Error: --appendix requires a slug (e.g. contributions-balaji-reddie)"
+      usage
+    fi
+    local manifest="$MANIFEST_DIR/appendix-${slug}-manifest.yml"
+    if [[ ! -f "$manifest" ]]; then
+      echo "Error: No manifest found at $manifest"
+      exit 1
+    fi
+
+    local manifest_pdf="" manifest_content=""
+    while IFS='=' read -r key value; do
+      case "$key" in
+        PDF_FILE)    manifest_pdf="$value" ;;
+        CONTENT_DIR) manifest_content="$value" ;;
+      esac
+    done < <(read_appendix_manifest "$manifest")
+
+    if [[ -z "$manifest_pdf" || -z "$manifest_content" ]]; then
+      echo "Error: appendix manifest must declare pdf_file and content_dir"
+      exit 1
+    fi
+
+    pdf_file="$PDF_DIR/$manifest_pdf"
+    qmd_dir="$REPO_ROOT/$manifest_content"
+    label="Appendix: $slug"
+  elif [[ -n "${1:-}" && "$1" =~ ^[0-9]+$ ]]; then
+    local day_num="$1"
+    if (( day_num < 1 || day_num > 12 )); then
+      echo "Error: day-number must be between 1 and 12"
+      exit 1
+    fi
+
+    local prefix
+    prefix=$(day_to_prefix "$day_num")
+    local day_dir
+    day_dir=$(printf "day-%02d" "$day_num")
+
+    local pdf_glob=( "$PDF_DIR/${prefix}".Day.*.pdf )
+    pdf_file="${pdf_glob[0]}"
+    if [[ ! -e "$pdf_file" ]]; then
+      echo "Error: No PDF found for Day $day_num (prefix $prefix) in $PDF_DIR"
+      exit 1
+    fi
+
+    qmd_dir="$REPO_ROOT/content/days/$day_dir"
+    label="Day $day_num"
+  else
     usage
   fi
 
-  if (( day_num < 1 || day_num > 12 )); then
-    echo "Error: day-number must be between 1 and 12"
-    exit 1
-  fi
-
-  check_deps
-
-  local prefix
-  prefix=$(day_to_prefix "$day_num")
-  local day_dir
-  day_dir=$(printf "day-%02d" "$day_num")
-
-  # Find the source PDF
-  local pdf_file
-  local pdf_glob=( "$PDF_DIR/${prefix}".Day.*.pdf )
-  pdf_file="${pdf_glob[0]}"
   if [[ ! -e "$pdf_file" ]]; then
-    echo "Error: No PDF found for Day $day_num (prefix $prefix) in $PDF_DIR"
+    echo "Error: PDF not found at $pdf_file"
     exit 1
   fi
 
-  # Check QMD directory exists
-  local qmd_dir="$CONTENT_DIR/$day_dir"
   if [[ ! -d "$qmd_dir" ]]; then
     echo "Error: No content directory found at $qmd_dir"
     exit 1
@@ -264,18 +328,19 @@ main() {
     exit 1
   fi
 
-  # local is fine here — trap runs in the same shell process and can see it
-  local tmpdir
-  tmpdir=$(mktemp -d)
-  trap 'rm -rf "$tmpdir" 2>/dev/null || true' EXIT
+  # TMPDIR_CLEANUP is a script-level global so the EXIT trap can still see
+  # it after main() returns (under set -u, a local would be unbound).
+  TMPDIR_CLEANUP=$(mktemp -d)
+  local tmpdir="$TMPDIR_CLEANUP"
+  trap 'rm -rf "$TMPDIR_CLEANUP" 2>/dev/null || true' EXIT
 
   echo "=========================================="
   echo "  Transcription Validation Report"
-  echo "  Day $day_num"
+  echo "  $label"
   echo "=========================================="
   echo ""
   echo "Source PDF: $(basename "$pdf_file")"
-  echo "QMD dir:   $day_dir/"
+  echo "QMD dir:   ${qmd_dir#"$REPO_ROOT/"}/"
   echo "QMD files: ${#qmd_files[@]}"
   echo ""
 

--- a/scripts/validate-transcription.sh
+++ b/scripts/validate-transcription.sh
@@ -265,6 +265,10 @@ main() {
       echo "Error: --appendix requires a slug (e.g. contributions-balaji-reddie)"
       usage
     fi
+    if [[ ! "$slug" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+      echo "Error: slug must contain only letters, digits, hyphens, and underscores"
+      exit 1
+    fi
     local manifest="$MANIFEST_DIR/appendix-${slug}-manifest.yml"
     if [[ ! -f "$manifest" ]]; then
       echo "Error: No manifest found at $manifest"

--- a/workflow/CONVERSION_GUIDE.md
+++ b/workflow/CONVERSION_GUIDE.md
@@ -113,6 +113,50 @@ Each chapter is verified by reading back the `.qmd` file before moving to the ne
 4. Run `quarto preview` to check rendering
 5. Fix any issues found
 
+#### Phase 4 for appendix content
+
+Both scripts support an `--appendix <slug>` mode for content that lives in
+`content/appendix/<slug>/` rather than `content/days/day-XX/`. The mode reads
+manifest-declared paths instead of deriving them from the day number, so the
+same scripts cover prose-only appendices (e.g. the Balaji Reddie
+contributions, Optional Extras) and future appendix PDFs without further
+changes.
+
+```bash
+./scripts/validate-transcription.sh --appendix contributions-balaji-reddie
+./scripts/check-structure.sh --appendix contributions-balaji-reddie
+```
+
+**Manifest location:** `workflow/validation/appendix-<slug>-manifest.yml`.
+
+**Minimum manifest fields** (see the Balaji manifest for a worked example):
+
+```yaml
+slug: contributions-balaji-reddie
+pdf_file: Q.Contributions.from.Balaji.Reddie.11Sep21.pdf
+content_dir: content/appendix/contributions-balaji-reddie
+interactive_checks: false   # true (default) runs viewof + download-button checks
+
+chapters:
+  - file: "00-introduction.qmd"
+    figures: []
+    headings:
+      - "An introduction to a System of Profound Knowledge"
+```
+
+For prose-only appendices set `interactive_checks: false` — the viewof and
+download-button checks are then skipped and only figure existence and
+heading match run per chapter. Interactive appendices (those with OJS input
+widgets or download buttons) should either omit `interactive_checks` or set
+it to `true`, and populate `viewof_count` / `has_download_button` per chapter
+exactly as day manifests do.
+
+**PDF prefix beyond D–O:** The day scripts hard-code the `D–O` letter
+prefixes for source PDFs. Appendix manifests sidestep that by naming the
+PDF file directly (`pdf_file:`), so any prefix — `P` (Appendix proper), `Q`
+(Balaji contributions), `R` (References), `S` (Optional Extras), or future
+additions — works without script changes.
+
 ### Phase 5: Integrate
 
 1. Wire new chapters into `_quarto.yml` under the correct `part:`

--- a/workflow/validation/appendix-contributions-balaji-reddie-manifest.yml
+++ b/workflow/validation/appendix-contributions-balaji-reddie-manifest.yml
@@ -1,0 +1,77 @@
+# Appendix structural manifest: Contributions from Balaji Reddie
+# Source PDF: Q.Contributions.from.Balaji.Reddie.11Sep21.pdf
+#
+# Prose-only appendix — interactive_checks is false so the viewof and
+# download-button checks are skipped. Figure and heading checks still run.
+
+slug: contributions-balaji-reddie
+pdf_file: Q.Contributions.from.Balaji.Reddie.11Sep21.pdf
+content_dir: content/appendix/contributions-balaji-reddie
+interactive_checks: false
+
+chapters:
+  - file: "00-introduction.qmd"
+    figures: []
+    headings:
+      - "An introduction to a System of Profound Knowledge"
+
+  - file: "01-prelude-a-system.qmd"
+    figures: []
+    headings:
+      - "The aim of a system"
+      - "Interconnections"
+      - 'The "most important" part of the system'
+      - "Cause and effect may be far apart"
+      - "Comparing, competing, ranking, rating"
+      - "Optimise or maximise?"
+      - 'Performing "within limits"'
+
+  - file: "02-prelude-b-statistical-thinking.qmd"
+    figures: []
+    headings:
+      - "Normal and abnormal variation"
+      - "Getting to work on time"
+      - "Computing the process limits"
+      - "What we've covered so far"
+      - "Two true stories"
+      - "Knee-jerk reactions"
+      - "How *not* to manage a process"
+      - "More wisdom from Dr Shewhart"
+      - "Discussion"
+
+  - file: "03-prelude-c-learning.qmd"
+    figures: []
+    headings:
+      - "What makes the scooter start?"
+      - "Information and knowledge"
+      - "A further improvement to the theory"
+      - "Why is the Sun so bright?"
+      - "A theory may only be a hunch"
+      - "Theory: the starting-point for learning"
+      - "Summary"
+
+  - file: "04-prelude-d-people.qmd"
+    figures: []
+    headings:
+      - '"What is the job of a teacher?"'
+      - 'Does pay "motivate"?'
+      - "Competition"
+      - "Competing against or competing with?"
+      - 'Is it "natural" to compete *against*?'
+      - "Are we no better than rats?"
+
+  - file: "05-coda.qmd"
+    figures: []
+    headings: []
+
+  - file: "06-lessons-from-history.qmd"
+    figures: []
+    headings:
+      - "INTRODUCTION"
+      - '"… BUT THEY DON''T KNOW WHAT TO COPY!"'
+      - "BACK TO DEMING'S LEGACY"
+
+  - file: "07-indias-missed-opportunity.qmd"
+    figures: []
+    headings:
+      - "Approvals, Acknowledgments and Information"


### PR DESCRIPTION
## Summary

- Both `check-structure.sh` and `validate-transcription.sh` now accept `--appendix <slug>` in addition to the existing `<day-number>` mode, reading `content_dir` and `pdf_file` from a manifest at `workflow/validation/appendix-<slug>-manifest.yml`.
- This removes the hardcoded `content/days/` path and the D–O letter-prefix mapping so appendix PDFs (`P`, `Q`, `R`, `S`) and future additions work without further script changes.
- Prose-only appendices can set `interactive_checks: false` to skip the viewof and download-button checks — figure existence and heading match still run.
- Added a worked manifest at `workflow/validation/appendix-contributions-balaji-reddie-manifest.yml`.
- Documented the appendix path in `workflow/CONVERSION_GUIDE.md` Phase 4.
- Bonus: fixed a pre-existing `unbound variable` warning at the EXIT cleanup in `validate-transcription.sh`.

Closes #186.

## Why this exists

Issue #133 was the first appendix conversion (Balaji Reddie contributions). The day-scoped validation scripts couldn't cover it, so Phase 4 was partially skipped. This captures the pattern while the gap is fresh so future appendix contributions stay at the same verification standard as the Days.

## Test plan

- [x] `./scripts/check-structure.sh --appendix contributions-balaji-reddie` → 16/16 PASS
- [x] `./scripts/validate-transcription.sh --appendix contributions-balaji-reddie` → 99% match (one garbled PDF header, one restructured paragraph — both expected per the script's own notes)
- [x] Day 1 regression: `./scripts/check-structure.sh 1` → 63/63 PASS
- [x] Day 1 regression: `./scripts/validate-transcription.sh 1` runs clean, no unbound-var warning at exit
- [x] Usage messages render cleanly for both `--appendix` (missing slug) and bare invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)