### PR TITLE
Add per-chapter reading-time indicator (#169)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -176,6 +176,9 @@ book:
     - content/appendix/contributions-balaji-reddie/07-indias-missed-opportunity.qmd
     - content/appendix/11-references-and-sources.qmd
 
+filters:
+  - filters/reading-time.lua
+
 format:
   html:
     theme: cosmo

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -885,3 +885,15 @@ button:focus,
   .dyslexia-toggle { display: none !important; }
 }
 
+.reading-time {
+  margin-top: -0.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+  color: #6c757d;
+  font-style: italic;
+}
+
+@media print {
+  .reading-time { display: none !important; }
+}
+

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -889,7 +889,7 @@ button:focus,
   margin-top: -0.5rem;
   margin-bottom: 1.5rem;
   font-size: 0.9rem;
-  color: #6c757d;
+  color: var(--bs-secondary-color, #6c757d);
   font-style: italic;
 }
 

--- a/filters/reading-time.lua
+++ b/filters/reading-time.lua
@@ -68,10 +68,14 @@ local function count_blocks(blocks)
   for _, b in ipairs(blocks) do
     if b.t == "CodeBlock" or b.t == "RawBlock" or b.t == "HorizontalRule" then
       -- skip
-    elseif (b.t == "Div" or b.t == "Para" or b.t == "Plain") and has_class(b, "hidden") then
+    elseif b.t == "Div" and has_class(b, "hidden") then
       -- skip Quarto's injected navigation/meta blocks
     elseif b.t == "Para" or b.t == "Plain" then
       total = total + count_words(stringify_inlines(b.content))
+    elseif b.t == "LineBlock" then
+      for _, line in ipairs(b.content) do
+        total = total + count_words(stringify_inlines(line))
+      end
     elseif b.t == "Header" and b.level > 1 then
       total = total + count_words(stringify_inlines(b.content))
     elseif b.t == "BlockQuote" then
@@ -90,10 +94,31 @@ local function count_blocks(blocks)
     elseif b.t == "Div" then
       total = total + count_blocks(b.content)
     elseif b.t == "Table" then
-      total = total + count_words(pandoc.utils.stringify(b))
+      -- Stringify the whole table and subtract caption words so
+      -- captions are excluded, consistent with image captions.
+      local caption_words = 0
+      if b.caption and b.caption.long then
+        caption_words = count_words(pandoc.utils.stringify(b.caption.long))
+      end
+      if b.caption and b.caption.short then
+        caption_words = caption_words
+          + count_words(pandoc.utils.stringify(b.caption.short))
+      end
+      total = total + math.max(0,
+        count_words(pandoc.utils.stringify(b)) - caption_words)
     end
   end
   return total
+end
+
+local function html_escape(s)
+  return (s:gsub("[&<>\"']", {
+    ["&"] = "&amp;",
+    ["<"] = "&lt;",
+    [">"] = "&gt;",
+    ['"'] = "&quot;",
+    ["'"] = "&#39;",
+  }))
 end
 
 local function indicator_block(minutes, has_activity)
@@ -103,7 +128,7 @@ local function indicator_block(minutes, has_activity)
     or "Estimated reading time"
   local html = string.format(
     '<p class="reading-time" aria-label="%s">~ %d min reading%s</p>',
-    label, minutes, suffix
+    html_escape(label), minutes, html_escape(suffix)
   )
   return pandoc.RawBlock("html", html)
 end

--- a/filters/reading-time.lua
+++ b/filters/reading-time.lua
@@ -1,0 +1,136 @@
+-- Inject an estimated reading time under each chapter's H1.
+-- Counts prose words (excluding code, raw HTML, image captions) and
+-- divides by 200 wpm. Suppresses output on very short chapters.
+
+local WPM = 200
+-- Chapters below this threshold are typically activity-only pages
+-- (prompts + embedded widgets); a "1 min read" estimate would
+-- understate engagement, so we simply omit the indicator.
+local MIN_WORDS = 50
+
+local function count_words(s)
+  if not s or s == "" then return 0 end
+  local n = 0
+  for _ in s:gmatch("%S+") do n = n + 1 end
+  return n
+end
+
+local function stringify_inlines(inlines)
+  local parts = {}
+  for _, el in ipairs(inlines) do
+    if el.t == "Str" then
+      parts[#parts + 1] = el.text
+    elseif el.t == "Space" or el.t == "SoftBreak" or el.t == "LineBreak" then
+      parts[#parts + 1] = " "
+    elseif el.t == "Image" or el.t == "RawInline" or el.t == "Code" then
+      -- skip image captions, inline raw HTML, and inline code
+    elseif el.content then
+      parts[#parts + 1] = stringify_inlines(el.content)
+    end
+  end
+  return table.concat(parts, "")
+end
+
+local function has_class(block, class)
+  if not block.attr or not block.attr.classes then return false end
+  for _, c in ipairs(block.attr.classes) do
+    if c == class then return true end
+  end
+  return false
+end
+
+-- Activity markers we look for anywhere in the doc (code blocks
+-- included, since widgets live inside ojs chunks).
+local function detect_activity(blocks)
+  for _, b in ipairs(blocks) do
+    if b.t == "CodeBlock" then
+      if b.text and (b.text:find("viewof", 1, true)
+                     or b.text:find("Inputs.textarea", 1, true)
+                     or b.text:find("createDownloadButton", 1, true)) then
+        return true
+      end
+    elseif b.t == "Div" then
+      if has_class(b, "thought") then return true end
+      if detect_activity(b.content) then return true end
+    elseif b.t == "BlockQuote" then
+      if detect_activity(b.content) then return true end
+    elseif b.t == "BulletList" or b.t == "OrderedList" then
+      for _, item in ipairs(b.content) do
+        if detect_activity(item) then return true end
+      end
+    end
+  end
+  return false
+end
+
+local function count_blocks(blocks)
+  local total = 0
+  for _, b in ipairs(blocks) do
+    if b.t == "CodeBlock" or b.t == "RawBlock" or b.t == "HorizontalRule" then
+      -- skip
+    elseif (b.t == "Div" or b.t == "Para" or b.t == "Plain") and has_class(b, "hidden") then
+      -- skip Quarto's injected navigation/meta blocks
+    elseif b.t == "Para" or b.t == "Plain" then
+      total = total + count_words(stringify_inlines(b.content))
+    elseif b.t == "Header" and b.level > 1 then
+      total = total + count_words(stringify_inlines(b.content))
+    elseif b.t == "BlockQuote" then
+      total = total + count_blocks(b.content)
+    elseif b.t == "BulletList" or b.t == "OrderedList" then
+      for _, item in ipairs(b.content) do
+        total = total + count_blocks(item)
+      end
+    elseif b.t == "DefinitionList" then
+      for _, item in ipairs(b.content) do
+        total = total + count_words(stringify_inlines(item[1]))
+        for _, def in ipairs(item[2]) do
+          total = total + count_blocks(def)
+        end
+      end
+    elseif b.t == "Div" then
+      total = total + count_blocks(b.content)
+    elseif b.t == "Table" then
+      total = total + count_words(pandoc.utils.stringify(b))
+    end
+  end
+  return total
+end
+
+local function indicator_block(minutes, has_activity)
+  local suffix = has_activity and " + activities" or ""
+  local label = has_activity
+    and "Estimated reading time; this chapter also contains activities that add time"
+    or "Estimated reading time"
+  local html = string.format(
+    '<p class="reading-time" aria-label="%s">~ %d min reading%s</p>',
+    label, minutes, suffix
+  )
+  return pandoc.RawBlock("html", html)
+end
+
+function Pandoc(doc)
+  local words = count_blocks(doc.blocks)
+  if words < MIN_WORDS then return doc end
+
+  local minutes = math.max(1, math.ceil(words / WPM))
+  local has_activity = detect_activity(doc.blocks)
+  local out = pandoc.List()
+  local inserted = false
+
+  for _, b in ipairs(doc.blocks) do
+    out:insert(b)
+    if not inserted and b.t == "Header" and b.level == 1 then
+      out:insert(indicator_block(minutes, has_activity))
+      inserted = true
+    end
+  end
+
+  -- If no H1 is present in the body (Quarto renders title from YAML),
+  -- inject at the very top so it still appears under the page title.
+  if not inserted then
+    out:insert(1, indicator_block(minutes, has_activity))
+  end
+
+  doc.blocks = out
+  return doc
+end

--- a/workflow/CONVERSION_GUIDE.md
+++ b/workflow/CONVERSION_GUIDE.md
@@ -504,6 +504,29 @@ The French phrase <span lang="fr">raison d'être</span> captures this well.
 Use ISO 639-1 codes: `ja` Japanese, `de` German, `fr` French, `la` Latin,
 `es` Spanish.
 
+### Reading-time indicator
+
+Every chapter is automatically annotated with an estimated reading time
+injected under the H1 by `filters/reading-time.lua`. The filter counts
+prose in paragraphs, list items, blockquotes, tables, and H2+ headings;
+it skips `CodeBlock`, `RawBlock`, image captions, and Quarto's injected
+hidden navigation/meta divs. Minutes are computed at 200 wpm and
+rounded up.
+
+The filter also detects activity content (`viewof`, `Inputs.textarea`,
+`createDownloadButton`, or a `.thought` div) and appends
+"+ activities" to the label so readers know that prompts, reflections,
+and downloads add to the prose estimate. Output looks like:
+
+- `~ 6 min reading` — prose-only chapter
+- `~ 6 min reading + activities` — chapter with embedded widgets
+
+Chapters with fewer than 50 prose words omit the indicator rather than
+misrepresent engagement.
+
+No per-chapter action is required — the filter is registered in
+`_quarto.yml` and runs for every rendered page.
+
 ---
 
 ## Inter-Day Cross-References


### PR DESCRIPTION
## Summary

- Adds `filters/reading-time.lua`, a Pandoc Lua filter registered in `_quarto.yml`, that injects an estimated reading time under each chapter's H1.
- Counts prose words at 200 wpm, excluding `CodeBlock`, `RawBlock`, image captions, and Quarto's hidden nav/meta divs (which would otherwise inflate counts ~3×).
- Detects chapters that embed activity widgets (`viewof`, `Inputs.textarea`, `createDownloadButton`, or a `.thought` div) and appends "+ activities" to the label so the number isn't misread as total engagement time on activity-heavy pages.
- Chapters with fewer than 50 prose words omit the indicator rather than displaying a misleading "~ 1 min" on activity-only pages.
- Adds a muted-italic CSS rule for `.reading-time` (hidden in print).
- Documents the mechanism in `workflow/CONVERSION_GUIDE.md`.

## Why

Per issue #169, readers — especially those with cognitive fatigue or time constraints — benefit from knowing how long a chapter will take so they can plan reading in blocks. The existing per-chapter clock (`create_clock`) is a time-of-day pacing cue, not a duration, so the two indicators are complementary. The "+ activities" variant was added during review to avoid under-reporting engagement on activity-heavy chapters like Day 8.

## Test plan

- [x] `quarto render` completes with no warnings
- [x] All 120 chapters rendered; indicator present on every chapter above the 50-word threshold
- [x] Sample numeric spot-checks line up with `wc -w` against a 200 wpm baseline (e.g. 453-word coda → 3 min, 1825-word Deming (Re)discovered → 9 min)
- [x] Activity detection works: Day 8 `02-joy-in-work.qmd` (ojs-heavy) shows "+ activities"; Balaji coda (prose-only) does not
- [x] Layout verified on clock-column chapter (`day-01/01-overture.qmd`): indicator sits between H1 and `.columns` scaffold, does not collide with clock
- [ ] Reviewer to eyeball a few chapters in the preview to confirm the visual tone matches the course voice

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)