### PR TITLE
Align statisticians' weekly image widths to 100% (#255)

### DIFF
--- a/content/days/day-02/07-some-recollections.qmd
+++ b/content/days/day-02/07-some-recollections.qmd
@@ -66,7 +66,7 @@ don't take too long about it!
 :::: {.columns}
 ::: {.column width="55%"}
 
-![Week 1 of professional statisticians' results as a table of data.](/assets/images/day-02/image-7.png){fig-align="center" width="30%" .lightbox}
+![Week 1 of professional statisticians' results as a table of data.](/assets/images/day-02/image-7.png){fig-align="center" width="100%" .lightbox}
 
 :::
 ::: {.column width="45%"}
@@ -82,7 +82,7 @@ viewof thought_2e_i = Inputs.textarea({label: "Your comments on the Week 1 resul
 :::: {.columns}
 ::: {.column width="55%"}
 
-![Week 2 of professional statisticians' results as a table of data.](/assets/images/day-02/image-8.png){fig-align="center" width="40%" .lightbox}
+![Week 2 of professional statisticians' results as a table of data.](/assets/images/day-02/image-8.png){fig-align="center" width="100%" .lightbox}
 
 :::
 ::: {.column width="45%"}
@@ -96,7 +96,7 @@ viewof thought_2e_ii = Inputs.textarea({label: "Your comments on the Week 2 resu
 :::: {.columns}
 ::: {.column width="55%"}
 
-![Week 3 of professional statisticians' results as a table of data.](/assets/images/day-02/image-9.png){fig-align="center" width="50%" .lightbox}
+![Week 3 of professional statisticians' results as a table of data.](/assets/images/day-02/image-9.png){fig-align="center" width="100%" .lightbox}
 
 :::
 ::: {.column width="45%"}
@@ -115,7 +115,7 @@ fourth week, followed in turn by 10, 7 and 8 in their second shift.
 :::: {.columns}
 ::: {.column width="55%"}
 
-![Week 4 of professional statisticians' results as a table of data.](/assets/images/day-02/image-10.png){fig-align="center" width="60%" .lightbox}
+![Week 4 of professional statisticians' results as a table of data.](/assets/images/day-02/image-10.png){fig-align="center" width="100%" .lightbox}
 
 :::
 ::: {.column width="45%"}


### PR DESCRIPTION
## Summary
- Change the four Pause for Thought 2-e statisticians' weekly images (Day 2 Ch 7) from escalating widths (30/40/50/60%) to a uniform `width=\"100%\"`, matching the Spaniards' weekly images and removing the asymmetry between the two halves of the exercise.

Closes #255.

## Test plan
- [ ] Quarto preview shows Weeks 1-4 statisticians' images at the same scale as the Spaniards' weekly images.
- [ ] No overflow of the 55% column or pushing of the adjacent textarea off layout.
- [ ] `.lightbox` click-to-enlarge still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)