### PR TITLE
Document pa11y ignore rationales + /merge-pr skill guard (#257)

### DIFF
--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -11,6 +11,6 @@ Perform these steps in order:
 
 3. **Merge**: Merge the PR using `gh pr merge` with the `--squash` flag and `--delete-branch` to clean up the remote branch.
 
-4. **Sync local**: After merging, switch to main, pull latest, and delete the local feature branch (same as `/sync-main`).
+4. **Sync local**: After merging, switch to main and pull latest. `gh pr merge --delete-branch` usually removes the local feature branch too (when run from its checkout), so only run `git branch -D <name>` if `git branch --list <name>` still shows it — otherwise skip silently.
 
 5. **Confirm**: Tell the user the PR has been merged and the local repo is synced.

--- a/accessibility.qmd
+++ b/accessibility.qmd
@@ -33,6 +33,8 @@ The panel currently contains:
 
 Every pull request to the repository runs [pa11y](https://pa11y.org/) against the rendered site. The build fails if any WCAG 2.1 AA issue is detected, so the main branch is kept passing at all times.
 
+A small set of pa11y rules are suppressed in `.pa11yci.json` — chiefly framework-level false positives or rules whose substantive remediation is scoped to other tracked issues. The rationale for each suppression is documented in [`docs/pa11y-ignores.md`](https://github.com/lddurbin/twelve_days_to_deming/blob/main/docs/pa11y-ignores.md), which should be updated whenever the ignore list changes.
+
 ## What's still to come
 
 Planned improvements are tracked on GitHub under the [accessibility label](https://github.com/lddurbin/twelve_days_to_deming/issues?q=is%3Aissue+is%3Aopen+label%3Aaccessibility). Current priorities include long-descriptions for the statistical charts across Days 4–12, a per-chapter text-to-speech control, and an estimated reading-time indicator.

--- a/docs/pa11y-ignores.md
+++ b/docs/pa11y-ignores.md
@@ -1,0 +1,53 @@
+# pa11y Ignore Rules
+
+`.pa11yci.json` cannot carry inline comments (it is plain JSON). This file records the rationale for each WCAG rule listed in the `ignore` array, so future audits don't need to spelunk through `git log` to understand why a rule was suppressed.
+
+Each entry should record:
+
+- **Rule code** and a one-line description of what HTMLCS checks for.
+- **Why suppressed** — typically upstream Quarto emission, framework-level false positive, or scoped-to-a-different-issue.
+- **Last verified** — date the suppression was last confirmed still necessary, so stale entries can be re-audited.
+
+If you remove a rule from `.pa11yci.json`, also remove the entry below.
+
+## Active suppressions
+
+### `WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.EmptyNoId`
+
+**What it checks.** Anchors must have accessible text; the `H91.A.EmptyNoId` variant fires when a link has no visible text and no `id`.
+
+**Why suppressed.** Quarto's sidebar accordion toggles are anchors that use `aria-label` rather than visible text for their accessible name. pa11y/HTMLCS does not recognise `aria-label` as an accessible-name source for this rule, producing a false positive on a correctly-labelled control.
+
+**Source.** Added in #183 baseline triage (#164).
+
+**Last verified.** 2026-04-25.
+
+### `WCAG2AA.Principle1.Guideline1_1.1_1_1.H37`
+
+**What it checks.** `<img>` elements must have an `alt` attribute.
+
+**Why suppressed.** R/ggplot figures are emitted by Quarto without `alt` text. The substantive fix is long-descriptions on charts, which is scoped to its own work in #159 (Days 2–3) and #160 (remaining days). Suppressing here prevents the pa11y check from blocking unrelated PRs while that audit is in progress; the long-description issues will close out the underlying gap.
+
+**Source.** Added in #183 baseline triage (#164).
+
+**Last verified.** 2026-04-25. Re-audit when #159 and #160 close — the suppression should likely be lifted then.
+
+### `WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2`
+
+**What it checks.** `<form>` elements must contain a submit-style control (`<input type="submit">`, `<button type="submit">`, etc.).
+
+**Why suppressed.** OJS-driven interactive inputs (used across the activity widgets on Days 2, 3, and 6) are reactive controls — they update their bound values on change rather than on form submit. They are not traditional submit-based forms, so the rule does not apply.
+
+**Source.** Added in #183 baseline triage (#164).
+
+**Last verified.** 2026-04-25.
+
+### `WCAG2AA.Principle4.Guideline4_1.4_1_1.F77`
+
+**What it checks.** Element IDs must be unique within a document (the historical "duplicate id" parsing rule).
+
+**Why suppressed.** Quarto's dual-theme configuration emits two `<link>` tags for the active and prefetched stylesheet, sharing `id="quarto-bootstrap"` and `id="quarto-text-highlighting-styles"`, so its built-in `quartoToggleColorScheme` JS can swap between them. The duplicate IDs are intrinsic to the upstream theme-toggle mechanism, not project code. Note that **WCAG 2.2 removed the duplicate-id criterion entirely** (Success Criterion 4.1.1 Parsing), reflecting that modern browsers and assistive technologies tolerate non-unique IDs without harm — so this suppression aligns with the criterion's evolution.
+
+**Source.** Added during #256 review (commit `a3a59a8`).
+
+**Last verified.** 2026-04-25.


### PR DESCRIPTION
## Summary

- **#257 — pa11y ignore-rule docs.** Add `docs/pa11y-ignores.md` with one entry per WCAG rule in `.pa11yci.json`'s `ignore` array — what the rule checks for, why it's suppressed, source PR, and a "last verified" date so stale entries can be re-audited. Add a pointer from `accessibility.qmd`'s "Automated checks" section so anyone investigating the config discovers the doc.
- **/merge-pr skill guard (bundled).** `gh pr merge --delete-branch` removes the local feature branch when run from its checkout, so the skill's unconditional `git branch -D` was throwing spurious "branch not found" errors after every successful merge. Step 4 now checks `git branch --list <name>` first and skips silently when gh has already cleaned up.

The two changes are committed separately for clean revertability.

Closes #257.

## Test plan

- [ ] `docs/pa11y-ignores.md` covers all four rules currently in `.pa11yci.json`: H91.A.EmptyNoId, H37, H32.2, F77.
- [ ] Pointer from `accessibility.qmd` renders as a working link to the docs file on main.
- [ ] pa11y CI continues to pass on this PR (only docs touched).
- [ ] `/merge-pr` no longer prints "branch not found" on the next merge from a feature-branch checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)