### PR TITLE
Fix text overflow in info and return callouts

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -149,8 +149,9 @@ aside,
   background-color: #b6dde8;
   border: 2px solid black;
   text-align: center;
-  height: 40px;
-  line-height: 40px;
+  min-height: 40px;
+  line-height: 1.4;
+  padding: 10px;
   font-size: 15px;
   margin-bottom: 15px;
   font-style: italic;
@@ -167,8 +168,9 @@ aside,
   background-color: #c2d69b;
   border: 2px solid black;
   text-align: center;
-  height: 40px;
-  line-height: 40px;
+  min-height: 40px;
+  line-height: 1.4;
+  padding: 10px;
   font-size: 15px;
   margin-bottom: 15px;
   font-style: italic;
@@ -467,10 +469,6 @@ Usage:
   /* Callout adjustments */
   .return_callout,
   .info_callout {
-    height: auto;
-    min-height: 40px;
-    line-height: 1.4;
-    padding: 10px;
     margin: 10px 5px;
     font-size: 14px;
   }
@@ -825,8 +823,6 @@ button:focus,
   }
   html.dyslexic-font body .return_callout,
   html.dyslexic-font body .info_callout {
-    height: auto;
-    min-height: 40px;
     line-height: 1.5;
     padding: 8px 14px;
   }


### PR DESCRIPTION
## Summary

The Deming Point and Deadly Disease callouts (and their cousins) had been silently overflowing on desktop wherever their content wrapped past one line — Daisy noticed this on Day 4 Point 5, where the text spilled out the bottom of the green box and overlapped subsequent prose.

**Root cause:** `.info_callout` and `.return_callout` set `height: 40px; line-height: 40px` — an old single-line vertical-centring trick that breaks the moment text wraps. `height` is a hard ceiling, and `line-height: 40px` makes wrapped lines stack at 40px each below the box.

**Fix:** Replace with `min-height: 40px; line-height: 1.4; padding: 10px` so the box grows with content while keeping short single-line callouts visually padded. The mobile (line 469) and dyslexic-font (line 823) breakpoints had already discovered this exact answer; this PR lifts that pattern into the base rule and trims the now-redundant declarations from those overrides (they retain only their genuinely viewport- or font-specific tweaks).

**Scope:** ~22 callouts across Days 3–5 stop overflowing. CSS only, no markup or content changes; pa11y URL list unchanged.

## Test plan

- [x] `quarto render content/days/day-04/04-points-1-to-6.qmd` succeeds with no warnings
- [ ] Desktop preview of Day 4 Point 5 shows callout border enclosing all text (no spillover)
- [ ] Short single-line callouts (e.g. Day 3 drawing-activity callouts) still look reasonable — small green/blue strip with content visible
- [ ] Mobile breakpoint still applies its margin/font-size adjustments
- [ ] Dyslexic-font mode still applies its taller line-height/padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)