### PR TITLE
Add long-descriptions to charts in Days 1, 4-12 (#160)

### DIFF
--- a/content/days/day-01/11-deming-story.qmd
+++ b/content/days/day-01/11-deming-story.qmd
@@ -322,6 +322,13 @@ grViz("
 ")
 ```
 
+<details>
+<summary>Describe this diagram</summary>
+
+A left-to-right flow diagram of a whole production system. Four supplier nodes (A, B, C, D) feed materials into **Receipt and test of materials**, which passes them to **Production, assembly, inspection**, then to **Distribution**, and finally to **Consumers**. Crucially, the diagram is *not* a one-way assembly line: **Consumer research** loops back into **Design and redesign**, which in turn feeds Receipt, Production, and Distribution; **Tests of processes, machines, methods, costs** also feeds back into Receipt, Production, and Distribution. The lesson is that quality is built by treating the whole organisation — suppliers, production, distribution, consumers, design, and ongoing tests — as a single interconnected system, with information flowing back from the consumer end as much as forward.
+
+</details>
+
 <span class=deming_quote>
 2. Quality is determined by the management. Outgoing quality can not be better than the intentions of the management.</span> (Do you remember “Quality is made at the top” from the Overture?)
 
@@ -353,6 +360,13 @@ grViz("
   }
 ")
 ```
+
+<details>
+<summary>Describe this diagram</summary>
+
+A left-to-right chain of five linked boxes showing Deming's Chain Reaction. **Improve processes and product** leads to **Costs decrease**, which leads to **Capture the market with better quality and lower price**, which leads to **Stay in business**, which leads to **Provide jobs and more jobs**. The diagram makes a single causal claim: improving quality is what allows costs to fall, market share to grow, the business to survive, and employment to expand — in that order. It is the opposite of the conventional management belief that improving quality must *raise* costs.
+
+</details>
 
 <span class=neave_note>An updated version of the Chain Reaction appears on *Out of the Crisis* page 3 (both editions). There the final three steps stay the same. The first step becomes simply <span class=deming_quote>“Improve quality”</span>. But the second step is greatly expanded to show *why* costs decrease: <span class=deming_quote>“Costs decrease because of less rework, fewer mistakes, fewer delays, snags; better use of machine-time and materials”</span>. And a new step is inserted before “Capture the market …”: <span class=deming_quote>“Productivity improves”</span>.</span>
 

--- a/content/days/day-04/01-introduction.qmd
+++ b/content/days/day-04/01-introduction.qmd
@@ -32,6 +32,13 @@ My "Eureka" came through getting to know Dr Brian Joiner and some of his colleag
 
 ![The Joiner Triangle](/assets/images/day-04/joiner-triangle-simple.png){fig-align="center" width="60%" .lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+A simple equilateral triangle with one short phrase written at each of its three corners: **Obsession With Quality** at the top, **Scientific Approach** at the bottom-left, and **All One Team** at the bottom-right. There is no hierarchy implied — the three corners are co-equal foundations. The diagrammatic point is precisely that these three ideas are not separate items but a single connected whole; the lines of the triangle are doing the work of saying "these belong together".
+
+</details>
+
 In fact, the people at Joiner Associates used only *six* words, with the top of the Triangle being condensed to just "Quality". However, that struck me as being rather too nebulous. On page 11 you will see the more detailed version of the Triangle which shows some of the items to be included under each of the three headings. "Develop an obsession with quality" was the first item under that single word "Quality". With that and the fact that the final item was "Continual never-ending improvement", the thrust of that part of the Triangle was clearly far greater than conventional interpretations of "Quality" would imply; thus it seemed appropriate and helpful to take those two words "Obsession With" up into the title.
 
 We shall study the Joiner Triangle's three foundations in some depth on pages 4–13.

--- a/content/days/day-04/02-the-joiner-triangle.qmd
+++ b/content/days/day-04/02-the-joiner-triangle.qmd
@@ -254,6 +254,13 @@ In preparation for the First Project and as promised on page 2, here is a fuller
 
 ![The Expanded Joiner Triangle (Joiner Associates version)](/assets/images/day-04/joiner-triangle-expanded.png){fig-align="center" width="80%" .lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+The Joiner Triangle (Obsession With Quality at top, All One Team bottom-left, Scientific Approach bottom-right) with each corner now annotated by an adjacent box listing the topics that fall under that heading. **Obsession With Quality** lists: develop an obsession with quality (of products, processes, performance, work life); define minimum needs in operational terms (external and internal customers); quality is achieved by improved processes not by inspection; go beyond mere conformance to specifications; continual never-ending improvement. **All One Team** lists: cooperation vs competition; break down barriers; process improvement teams (cross-functional, cross-hierarchical); optimise the system as a whole; teams of teams. **Scientific Approach** lists: work on the system (flowcharting); understand variation; use process methodologies (charting, statistical thinking, special and common causes, seven tools, problem-solving and continual improvement); innovation of product and process. The diagram thus turns the three-word triangle into a working checklist for the First Project.
+
+</details>
+
 However, before we move on to the project, I need to consider further the Scientific Approach part of the Triangle. There are several reasons.
 
 First, you will have already read on *DemDim* page 35 that "Topics which can be included under this general heading *Scientific Approach*" take up a considerable proportion of that book. It includes notes of a few of the topics relevant to each of the Triangle's three foundations. Of course, everything there is useful but, in its context relevant here as representing foundations of Dr Deming's theory of management, some other choices could have been preferable. For example, I would have added two very important topics: Operational Definitions and the Deming Cycle. (However, I shall not include these in the box below since we won't be studying them here until Day 11.)
@@ -264,9 +271,23 @@ In the spirit of the expanded Joiner Triangle (but bearing in mind the above ref
 
 ![Neave's modified Scientific Approach box](/assets/images/day-04/scientific-approach-box.png){fig-align="center" width="55%" .lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+A single bordered box listing Neave's revised topics for the Scientific Approach corner of the Joiner Triangle. The five entries: collect data when possible, but also pay due regard to "unknowable figures"; summarise data on charts (non-process data: histograms; process data: run/control charts); understand variation; avoid tampering; out of control: find special causes / in control: improve processes. Compared with Joiner Associates' original list, Neave's version drops the heavy emphasis on individual tools and instead highlights the *judgements* a manager has to make — what to measure, how to display it, when to act, and when to leave alone.
+
+</details>
+
 So here for your convenience is the expanded Joiner Triangle again but now with my modified version of the Scientific Approach content:
 
 ![The Expanded Joiner Triangle (Neave's version)](/assets/images/day-04/joiner-triangle-combined.png){fig-align="center" width="80%" .lightbox}
+
+<details>
+<summary>Describe this diagram</summary>
+
+The full Expanded Joiner Triangle as Neave uses it in the rest of the course: same three corners (Obsession With Quality, All One Team, Scientific Approach) and same boxes for the first two corners as in the Joiner Associates version, but with the **Scientific Approach** box now replaced by Neave's revised list (collect data but also respect unknowable figures; summarise data on charts; understand variation; avoid tampering; act differently when in vs out of control). This is the version learners should keep beside them while working through the First Project.
+
+</details>
 
 <div class="separator">
   <div class="separator_white">

--- a/content/days/day-06/02-gallery-furniture.qmd
+++ b/content/days/day-06/02-gallery-furniture.qmd
@@ -218,6 +218,13 @@ In order for transformation to occur, the biggest change has to take place in ma
 
 ![Before and After comparison](/assets/images/day-06/before-after-table.png){fig-align="center" width="80%" .lightbox}
 
+<details>
+<summary>Describe this table</summary>
+
+A two-column **Before / After** table contrasting Gallery Furniture's old and new management mindset, row by row. *Before* (left, pink): individual events, firefighting, kicking butt, and taking names; goodbye to below-average staff; no education, high turnover — money spent on recruiting; frustrated because people didn't "get the message"; dwelled on problems and issued edicts; ignored the potential of competent, talented people. *After* (right, blue): view the company as a whole — not focus on individual events; view employees as assets; ROI: invest lots of money in the best asset, people; be less critical, appreciate diversity; job harder — fire prevention; found out lots of people can contribute, and want to. Every "After" entry is a system-level rewording of an individual-blame "Before" — it is the Deming transformation expressed as a vocabulary swap.
+
+</details>
+
 The benefits are many and great. People are happier on the job. There is better morale. Attitudes are high. Associates view the business holistically and are eager to contribute their ideas, opinions and talents. It is now OK to take a chance out on the edge where the rewards are to be found, rather than playing it safe in the middle of the road. No risk: no reward.
 
 ### Thank you, Dr Deming

--- a/content/days/day-07/05-thirteenth-obstacle.qmd
+++ b/content/days/day-07/05-thirteenth-obstacle.qmd
@@ -21,6 +21,13 @@ Here is a scale on which I have marked the two specification limits and also fou
 
 ![Specification limits diagram showing LSL and USL with four results: b and a near LSL, c and d near USL](/assets/images/day-07/specification-limits.png){.lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+A horizontal number line marked with two vertical tick-marks: **LSL** (Lower Specification Limit) on the left and **USL** (Upper Specification Limit) on the right. Four results sit close to those limits: **b** lies just outside LSL, **a** just inside it; **c** lies just inside USL, **d** just outside. By the conformance-to-specification rule, *a* and *c* are accepted while *b* and *d* are rejected — yet *a*–*b* and *c*–*d* are essentially indistinguishable from each other. The diagram is the visual punchline for Neave's "second logical flaw": a knife-edge between "OK" and "scrap" with no real difference in fitness for purpose.
+
+</details>
+
 Results "a" and "c" are "OK": they are within specifications, they have met requirements, and so the "things" represented by those figures are presumed suitable to be passed on to the customer, be the customer external or internal. Results "b" and "d" are outside specifications, they have not met requirements, and so the "things" represented by those figures are presumed not suitable to be passed on to the customer: they must be scrapped or reworked. These are very different consequences: "b" and "d" result in costly wastage or remedial action; "a" and "c" do not. *Yet obviously there is essentially no practical difference between "a" and "b" nor between "c" and "d".* That's the second logical flaw.
 
 An effective way of representing a more realistic view was described and discussed by Genichi Taguchi at a famous meeting in Tokyo in 1960 at which Dr Deming was present. The "Taguchi loss function" was not really a new idea, especially amongst mathematicians; but Dr Taguchi did a good job of making it known and showing its relevance in "the real world". It is obvious why it appealed to Dr Deming: it wholly avoids the illogicalities just demonstrated with regard to conformance to specifications, and it is entirely consistent with his thesis of continual improvement.
@@ -87,6 +94,13 @@ If you are not very confident about plotting points and drawing graphs, please f
 Just about everybody gets a graph which looks something like Figure 34 on *DemDim* page 173:
 
 ![Taguchi loss function parabola and Neave's plotted personal graph](/assets/images/day-07/taguchi-loss-function.png){.lightbox}
+
+<details>
+<summary>Describe this chart</summary>
+
+Two graphs stacked. The top graph is the abstract Taguchi loss function: a smooth U-shaped parabola with **loss** on the vertical axis and **measurement** on the horizontal axis, the curve bottoming out exactly at the **nominal** value and rising symmetrically away from it on both sides. The bottom graph is Neave's own plotted version, with seven Xs at his temperature/loss readings (95% at 6°C, 50% at 11°C, 15% at 16°C, 0% at 21°C, 10% at 26°C, 45% at 31°C, 85% at 36°C) joined by a smooth curve. His curve is recognisably the same U-shape but is *not quite symmetric* — losses rise faster on the cold side than on the hot side. The lesson: the precise mathematical parabola is the model, but real-life loss functions have the same general shape even when individuals are asymmetric.
+
+</details>
 
 This picture shows the nicely symmetric model often illustrated and used by mathematicians as the Taguchi loss function. Mathematicians know it as a "parabola". Actual loss functions are not usually exactly symmetric about the nominal/optimum value. Mine isn't, for I tend to lose efficiency rather more if I'm cold than if I'm hot; for many people it may be the other way round. So the fine detail doesn't matter—but the general shape does. Here is my graph:
 

--- a/content/days/day-08/05-introduction-to-the-major-activity.qmd
+++ b/content/days/day-08/05-introduction-to-the-major-activity.qmd
@@ -75,6 +75,13 @@ Here then is Table One, firstly as you will find it in the Major Activity (apart
 
 ![Table One — blank (left) and filled in with the DemDim example (right)](/assets/images/day-08/table-one-example.png){fig-align="center" width="90%" .lightbox}
 
+<details>
+<summary>Describe this table</summary>
+
+Two side-by-side worksheets sharing the same layout: a tall left column **Areas and their Options** (rows grouped by Area A in blue, Area B in orange, Area C in green) and three narrow columns on the right under **Effects of Options** (Effect on A, Effect on B, Effect on C). The grid has greyed-out cells that block off "off-diagonal" judgements — at this first phase each area is only allowed to record the effect of its own options on itself. The **left** worksheet is blank, ready to fill in. The **right** worksheet is the worked *DemDim* example: Area A has adopted three options (a1, a2, a3), Area B two (b1, b2), Area C three (c1, c2, c3) — eight options in total — each marked with a single **+** in its own area's column and nothing else. Subsequent tables in this chapter (Tables Two through Five) reprise the same blank-vs-filled side-by-side layout for later phases of the exercise; only their row content and which cells are open or greyed changes.
+
+</details>
+
 #### TABLE ONE
 
 So, as in *DemDim*, three options are adopted in both Areas A and C, and two options in Area B. Otherwise Table One simply shows that all eight options are advantageous (+) to the area that chose to adopt them—which, of course, is the sole interest in the first ("darkness") phase.

--- a/content/days/day-08/06-major-activity.qmd
+++ b/content/days/day-08/06-major-activity.qmd
@@ -19,7 +19,6 @@ As mentioned, the tables for the *DemDim* case are reproduced on these left-hand
 
 ::: {.column-margin}
 ![Table One — DemDim example](/assets/images/day-08/table-one-inset.png){.lightbox}
-:::
 
 <details>
 <summary>Describe this table</summary>
@@ -27,6 +26,7 @@ As mentioned, the tables for the *DemDim* case are reproduced on these left-hand
 A small inset reprise of the worked Table One from the previous chapter: three areas (A blue, B orange, C green) each show their adopted options (a1–a3, b1–b2, c1–c3) marked with a single **+** in their own "Effect on" column, off-diagonal cells greyed out. It sits alongside the activity step as a reminder of what the *DemDim* example looks like at this phase. Tables Two through Five reappear as similar margin insets later in the chapter, each showing the corresponding worked stage of the exercise; the layout convention is identical to Table One.
 
 </details>
+:::
 
 ```{ojs}
 //| echo: false

--- a/content/days/day-08/06-major-activity.qmd
+++ b/content/days/day-08/06-major-activity.qmd
@@ -21,6 +21,13 @@ As mentioned, the tables for the *DemDim* case are reproduced on these left-hand
 ![Table One — DemDim example](/assets/images/day-08/table-one-inset.png){.lightbox}
 :::
 
+<details>
+<summary>Describe this table</summary>
+
+A small inset reprise of the worked Table One from the previous chapter: three areas (A blue, B orange, C green) each show their adopted options (a1–a3, b1–b2, c1–c3) marked with a single **+** in their own "Effect on" column, off-diagonal cells greyed out. It sits alongside the activity step as a reminder of what the *DemDim* example looks like at this phase. Tables Two through Five reappear as similar margin insets later in the chapter, each showing the corresponding worked stage of the exercise; the layout convention is identical to Table One.
+
+</details>
+
 ```{ojs}
 //| echo: false
 import {

--- a/content/days/day-09/02-a-system.qmd
+++ b/content/days/day-09/02-a-system.qmd
@@ -18,6 +18,13 @@ Why did it finish up there? Simply because at the time of writing *DemDim* (1989
 
 ![Deming's "Organisation Viewed as a System" flow diagram](/assets/images/day-09/deming-flow-diagram.png){.lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+The famous "Organisation Viewed as a System" flow sketch — the same diagram Deming put on the blackboard at every Japanese top-management conference from 1950 onward, here reproduced in his hand-drawn-style blue. Materials and equipment from four suppliers (A, B, C, D) flow into **Receipt and test of materials**, then into **Production, assembly, inspection**, then into **Distribution**, and out to many **Consumers** (a fan of arrows, deliberately depicting one organisation serving many). Two feedback loops sit on top: **Tests of processes, machines, methods, costs** feeds *back* into Receipt and Production, and **Consumer research** flows *backwards* through **Design and redesign** to inform Receipt, Production and Distribution. The lesson is that organisation, suppliers and consumers form a single system, with information flowing from the consumer end back through the rest — not a one-way assembly line.
+
+</details>
+
 Note that, with his usual precise choice of words, Deming does not write "Customers" at the right-hand side of this diagram, but "Consumers". "Customer-Supplier Relationships" is an often-used phrase. However, the "customer" strictly refers to who *pays* for what is being bought rather than necessarily who *uses* it. Clearly it is the experience of, and information from, the *consumer* that is needed to aid the improvement implicit in the use of the flow diagram.
 
 ### What ignited Japan?
@@ -47,6 +54,13 @@ As we know, Dr Deming attributed to Walter Shewhart the origin of much of his th
 And who could doubt that that was true of his thoughts on "Production (or The Organisation) Viewed as a System" after seeing the diagram alongside? This is reproduced from page 45 of Shewhart's 1939 book: *Statistical Method from the Viewpoint of Quality Control*.
 
 ![Shewhart 1939 circle diagram](/assets/images/day-09/shewhart-circle.png){.lightbox}
+
+<details>
+<summary>Describe this diagram</summary>
+
+Shewhart's 1939 "OLD" vs "NEW" sketch, two diagrams stacked. **OLD**: three boxes joined by straight arrows in a single line — Step I **Specification**, Step II **Production**, Step III **Inspection**. The line ends; nothing comes back. **NEW**: the same three labels (Specification, Production, Inspection) but now arranged around a **circle**, each arrow leading to the next and the third leading back to the first. The whole pedagogical point is the difference between a line and a circle: the line stops; the circle turns Inspection into a feedback step that reshapes the next round of Specification, making continual improvement possible.
+
+</details>
 
 Were there a prize for the best-ever combination of simple and profound, this would be strong competition for the Experiment on Red Beads! Again, Shewhart was primarily concerned here with manufacturing applications, which explains his choice of the particular three words used in the two parts of the diagram. But that's not what is most important.
 
@@ -127,6 +141,13 @@ A dynamic scientific process of acquiring knowledge! Rather different from *done
 After referencing Shewhart's work just described, on *Out of the Crisis* pages 154–155[180–181] Dr Deming then goes on in his Figure 9 to reproduce the same concepts with some different words: simpler ones for the "Old Way" and a crucial expansion of the "New Way":
 
 ![Fig. 9a, 9b and 10 — The old way, the new way, and the helix](/assets/images/day-09/figures-9a-9b-10.png){.lightbox}
+
+<details>
+<summary>Describe this diagram</summary>
+
+Three sketches stacked vertically, all from *Out of the Crisis*. **Fig. 9a (the old way)**: a straight line of three numbered arrows — *Design it → Make it → Try to sell it*. The line ends at "sell it"; there is no return path. **Fig. 9b (the new way)**: a circle with four numbered points equally spaced around it; Deming's key change from Shewhart is that he adds a fourth step, *test the product in service*, so consumer feedback feeds back into Step 1. **Fig. 10 (the helix)**: the same four-step circle, but now drawn as a spiral expanding outward — round and round, each cycle larger than the last — depicting "never-ending improvement of quality, at lower and lower cost". The trio shows the progression: line → circle → helix.
+
+</details>
 
 He follows this with:
 

--- a/content/days/day-09/03-activity-9c-and-organisation-charts.qmd
+++ b/content/days/day-09/03-activity-9c-and-organisation-charts.qmd
@@ -70,6 +70,13 @@ Having established a "macro" flow diagram for the organisation (or whatever syst
 
 ![Complex organisation chart](/assets/images/day-09/org-chart-complex.png){.lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+A deliberately overwhelming sketch on a black background: dozens of small empty boxes (representing groups, departments, individuals) scattered across the page, with a tangle of pale lines criss-crossing between them. There is no visible top, no clean hierarchy, no orderly chain of command — interconnections run in every direction. The point is *not* that this is a usable chart but that this is what any real organisation actually looks like once you stop pretending the conventional pyramid org-chart tells the whole story. It contrasts sharply with Deming's deliberately simple flow diagram on the previous page; the lesson is that comprehensible, *macro* flow diagrams are useful, but ultra-detailed wall-sized maps like this one are not.
+
+</details>
+
 While addressing the British Deming Association's 1991 Annual Conference, Bill showed this picture with a comment to the effect that "this is what any organisation is". There are lots and lots of boxes (representing groups, departments, individuals, etc)---and also lots and lots of lines joining the boxes to indicate the numerous interconnections between them.
 
 So what is to be gained by constructing Deming's flow diagram? The important answer is that it helps us to change the way we think; and, as we have so often remarked before, what we think greatly affects what we do. It can therefore help management to start doing things differently. Such as what?

--- a/content/days/day-09/06-introductions-to-the-system.qmd
+++ b/content/days/day-09/06-introductions-to-the-system.qmd
@@ -15,6 +15,13 @@ So, on to our four introductions to the System of Profound Knowledge. First, hav
 
 ![Peter Scholtes's System of Profound Knowledge diagram](/assets/images/day-09/scholtes-sopk-diagram.png){.lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+Four large boxes arranged in a 2×2 grid, each pointing inward toward a small empty central box that holds the four parts together (the visual is reminiscent of jigsaw pieces meeting in the middle). The four boxes are: **top-left "Understanding of systems"** — the existence of systems and their impact on any result; the interdependence and interaction of networks of forces. **Top-right "Understanding a theory of knowledge"** — theory and prediction in the learning process; the interaction between theory and experience; operational definitions. **Bottom-left "Understanding variation"** — causes of variation and how to respond appropriately; tampering, and how leaders despite good intentions can increase variation. **Bottom-right "Understanding psychology and human behaviour"** — intrinsic vs extrinsic motivation; the effect of systems on people's performance; the effects of merit systems, incentive pay, carrots and sticks. The diagram's shape is the message: the four parts are *not* a list but a system that meets at the centre, each one shaping the others.
+
+</details>
+
 Particularly in your early days of learning about the System of Profound Knowledge, Peter's diagram here is well worth repeated attention. Although there are only two or three entries in each part, they are enough to remind you of the type and flavour of the content of each of the four parts, rather beyond that which merely their titles might imply. Take a little time to look through them carefully, say, three or four times before continuing.
 
 Advance notice: On Day 12, for still further learning and also amusement, we shall see Peter's superb parody of the above diagram: "A System of Profound Trouble"!

--- a/content/days/day-10/02-appreciation-for-a-system.qmd
+++ b/content/days/day-10/02-appreciation-for-a-system.qmd
@@ -132,6 +132,13 @@ An example of a system, well-optimised, is a good orchestra. The players are not
 
 ![Bowling team / Orchestra / Business interdependence spectrum](/assets/images/day-10/bowling-orchestra-business-spectrum.png){fig-align="center" width="70%" .lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+A horizontal scale labelled **LOW** at the left end and **HIGH** at the right end, with three labelled dots placed along it. **Bowling team** sits well over to the left (low interdependence — players succeed largely through individual effort). **Orchestra** sits well to the right (high interdependence — no soloist can save the piece if the section is not playing together). **Business** sits even slightly *further right* than Orchestra. The placement is the lesson: a business organisation needs *more* genuine teamwork than an orchestra, and very much more than a bowling team — yet many businesses are managed as if they were a bowling team.
+
+</details>
+
 <div class="neave_note">
 Low and high interdependence are respectively to the left and right. Paradoxically, a (ten-pin) bowling *team* can largely succeed through independent effort and brilliance of its players. An orchestra cannot: it needs a much higher degree of genuine teamwork. A business organisation needs even more.]
 </div>

--- a/content/days/day-11/03-theory-of-knowledge-theory-and-learning.qmd
+++ b/content/days/day-11/03-theory-of-knowledge-theory-and-learning.qmd
@@ -42,6 +42,13 @@ Finally, now that you have seen the Deming/Shewhart Cycle as well as being famil
 
 ![A Theory of Knowledge in seven words](/assets/images/day-11/theory-of-knowledge-circle.png){fig-align="center" width="60%" .lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+A clockwise circle of seven labelled words, each connected to the next by a curved arrow: **Theory → Question → Data → Prediction → Knowledge → Action → Wisdom → (back to Theory)**. There is no start or end — the cycle keeps going. The point is that knowledge does not arise from data alone; it begins with theory, runs through prediction (which the data either supports or refutes), and only then becomes knowledge — and only after acting on that knowledge does wisdom emerge, feeding back into a sharper theory. Strip out any of the seven and the circle breaks.
+
+</details>
+
 **Now turn to *DemDim* page 139 and read Chapter 9.** You'll be able to skip through some of these pages very quickly.
 
 *(Continue to Area 2, Step 2 overleaf.)*

--- a/content/days/day-12/02-your-radar-diagram.qmd
+++ b/content/days/day-12/02-your-radar-diagram.qmd
@@ -36,6 +36,13 @@ Let's suppose you've scored the strength of connection of Point 1 with both Unde
 
 ![Example radar diagram with Point 1 plotted](/assets/images/day-12/radar-diagram-small.png){fig-align="center" width="65%" .lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+A four-armed radar (or "kite") chart used as the worked example for Activity 12–a. The four arms — PSYCHOLOGY (top), SYSTEM (right), KNOWLEDGE (bottom), VARIATION (left) — each carry a 0-to-5 scale, with 0 at the centre and 5 at the tip. For Point 1 ("Create Constancy of Purpose"), Neave's illustrative scores are plotted: 5 on PSYCHOLOGY, 4 on SYSTEM, 3 on KNOWLEDGE, 5 on VARIATION. The four points are joined by broken green dashes (the chosen KEY for Point 1), forming a four-sided shape. Each of the 14 Points and five Diseases is plotted the same way, so 19 such shapes will eventually be overlaid on a single radar; the relative size and position of each shape will reveal which parts of the System of Profound Knowledge most strongly underpin which Point or Disease.
+
+</details>
+
 <div class="thought_commentary">
 
 ## ACTIVITY 12–a, Part 3

--- a/content/days/day-12/03-wisdom-from-peter-scholtes.qmd
+++ b/content/days/day-12/03-wisdom-from-peter-scholtes.qmd
@@ -32,6 +32,13 @@ To get you started, here is just a single thought for each of the six links:
 
 ![Peter Scholtes's diagram with sample interlink thoughts filled in](/assets/images/day-12/scholtes-profound-knowledge-filled.png){fig-align="center" width="90%" .lightbox}
 
+<details>
+<summary>Describe this diagram</summary>
+
+The same Scholtes 2×2 System of Profound Knowledge frame from Day 9 (Understanding of systems top-left, Understanding a theory of knowledge top-right, Understanding variation bottom-left, Understanding psychology and human behaviour bottom-right) — but now the *connecting* shapes between the four boxes (and the central "PREDICTION" diamond) carry sample sentences, in handwritten-style blue, that link one part to another. Examples Neave provides: "Communication and negotiation … require for optimisation operational definitions" linking systems to theory of knowledge; "If psychologists understood variation … they would no longer participate in … rating people" linking variation to psychology; "People learn in different ways" linking theory of knowledge to psychology. The point of the diagram is the *interlinks*, not the four parts themselves — the parts are already familiar; the work of Activity 12–b is to fill in your own interlinks.
+
+</details>
+
 Recall that, at the end of Day 11, I suggested you make some copies or, preferably, enlargements of this page. Now you may soon see why!
 
 <div class="thought_commentary">
@@ -49,6 +56,13 @@ Following some of the guidance on page 8---and anything else that comes into you
 Finally in this section of Wisdom from Peter Scholtes is his delightful---and instructive---representation of "A System of Profound Trouble"! I need add nothing in explanation.
 
 ![Peter Scholtes's "A System of Profound Trouble" diagram](/assets/images/day-12/system-of-profound-trouble.png){fig-align="center" width="90%" .lightbox}
+
+<details>
+<summary>Describe this diagram</summary>
+
+Peter Scholtes's parody of his own System of Profound Knowledge diagram — same 2×2 layout meeting at the centre, but every label is now negated. **Top-left "Not understanding systems":** changes here create problems somewhere else; barriers and divisiveness from internal competition; scapegoating and blaming; losing sight of customers. **Top-right "Not understanding a theory of knowledge":** changes without improvement; not learning from the past; problems remain unsolved; thought without action and action without thought; not knowing how to learn. **Bottom-left "Not understanding variation":** seeing trends where there are none and missing the real ones; blaming people for what they cannot control; no sense of system capability; "superstitious" management interventions. **Bottom-right "Not understanding psychology and human behaviour":** cynicism, demoralisation; paternalism, indignities; sadness, anguish, resentment; burnout; "a 'crazy-making' place"; **no joy in work, no pride of work**. The diagram is funny only until you read it twice — every entry is a recognisable everyday symptom of management without Profound Knowledge.
+
+</details>
 
 <div class="separator">
   <div class="separator_white">

--- a/workflow/validation/day-12-manifest.yml
+++ b/workflow/validation/day-12-manifest.yml
@@ -18,6 +18,9 @@ chapters:
       - "/assets/images/day-12/radar-diagram-large.png"
     headings:
       - "Section 1: YOUR RADAR DIAGRAM"
+      - "ACTIVITY 12–a, Part 1"
+      - "ACTIVITY 12–a, Part 2"
+      - "ACTIVITY 12–a, Part 3"
     has_download_button: false
 
   - file: "03-wisdom-from-peter-scholtes.qmd"
@@ -28,6 +31,7 @@ chapters:
       - "/assets/images/day-12/system-of-profound-trouble.png"
     headings:
       - "Section 2: WISDOM FROM PETER SCHOLTES"
+      - "ACTIVITY 12–b"
     has_download_button: false
 
   - file: "04-but-what-can-i-do.qmd"


### PR DESCRIPTION
## Summary

Closes #160. Applies the long-description pattern established for Days 2-3 in #159 to every remaining day in the course.

- **21 `<details>` blocks added** across 14 chapters in Days 1, 4, 6, 7, 8, 9, 10, 11, 12
- **26 images correctly skipped** per the documented rules in `workflow/PATTERNS.md` (decorative portraits, title cards, blank apparatus, repetitive series, content available verbatim elsewhere)
- **Day 5 had no qualifying images** (only a misleading-alt decorative separator)
- **Bonus fix**: Day 12 manifest debt — the four activity headings `ACTIVITY 12-a` Parts 1/2/3 and `ACTIVITY 12-b` were present in the chapters but missing from the manifest, so the structure check was failing pre-existingly. Same approach as the Day 2 manifest fix in #270.

The repetitive-series rule did meaningful work in Day 8: Tables 1-5 appear twice (once full-page, once as inline insets), so 10 candidate images collapse to 2 descriptions — one anchoring each variant.

## Test plan

- [x] `quarto render` on each of the 14 touched files — all rendered cleanly with no parse warnings
- [x] `./scripts/check-structure.sh N` for N in 1..12 — all pass; only pre-existing download-button warnings remain (raised as #271)
- [x] Coverage sweep: 47 candidate images audited, every unpaired image matches an explicit skip rule
- [ ] Reviewer to spot-check disclosure rendering on a sample chapter (Day 1 `11-deming-story`, Day 9 `02-a-system`, Day 12 `03-wisdom-from-peter-scholtes` are good ones — they cover grViz, static diagram, and the satirical "System of Profound Trouble" parody)

## Follow-ups

- #271 tracks the remaining manifest debt (download-button flags out of sync on Days 2, 10, 11) which surfaced during this audit but is out of scope here.
- Once #271 is merged, `H37` (img-alt) suppression in `.pa11yci.json` and `docs/pa11y-ignores.md` line 33 can be re-audited — the long-descriptions cover the pedagogical alt-text gap that suppression was working around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)