### PR TITLE
Sync download-button manifest flags with QMDs (#271)

### DIFF
--- a/workflow/validation/day-02-manifest.yml
+++ b/workflow/validation/day-02-manifest.yml
@@ -50,7 +50,7 @@ chapters:
     figures: []
     headings:
       - "ACTIVITY 2–f"
-    has_download_button: false
+    has_download_button: true
 
   - file: "07-some-recollections.qmd"
     viewof_count: 16
@@ -67,13 +67,13 @@ chapters:
       - "/assets/images/day-02/image-14.png"
     headings:
       - "PAUSE FOR THOUGHT 2–e"
-    has_download_button: false
+    has_download_button: true
 
   - file: "08-major-activity.qmd"
     viewof_count: 2
     figures: []
     headings: []
-    has_download_button: false
+    has_download_button: true
 
   - file: "09-postscript.qmd"
     viewof_count: 0

--- a/workflow/validation/day-10-manifest.yml
+++ b/workflow/validation/day-10-manifest.yml
@@ -16,7 +16,7 @@ chapters:
       - "/assets/images/day-10/bowling-orchestra-business-spectrum.png"
     headings:
       - "PART A: APPRECIATION FOR A SYSTEM"
-    has_download_button: false
+    has_download_button: true
 
   - file: "03-activity-10a.qmd"
     viewof_count: 38
@@ -30,7 +30,7 @@ chapters:
     figures: []
     headings:
       - "PART B: SOME KNOWLEDGE OF THEORY OF VARIATION (STATISTICAL THEORY)"
-    has_download_button: false
+    has_download_button: true
 
   - file: "05-activity-10b.qmd"
     viewof_count: 38

--- a/workflow/validation/day-11-manifest.yml
+++ b/workflow/validation/day-11-manifest.yml
@@ -16,20 +16,20 @@ chapters:
     figures: []
     headings:
       - "PART C: THEORY OF KNOWLEDGE"
-    has_download_button: false
+    has_download_button: true
 
   - file: "03-theory-of-knowledge-theory-and-learning.qmd"
     viewof_count: 4
     figures:
       - "/assets/images/day-11/theory-of-knowledge-circle.png"
     headings: []
-    has_download_button: false
+    has_download_button: true
 
   - file: "04-theory-of-knowledge-operational-definitions.qmd"
     viewof_count: 5
     figures: []
     headings: []
-    has_download_button: false
+    has_download_button: true
 
   - file: "05-activity-11a.qmd"
     viewof_count: 38
@@ -43,7 +43,7 @@ chapters:
     figures: []
     headings:
       - "PART D: KNOWLEDGE OF PSYCHOLOGY"
-    has_download_button: false
+    has_download_button: true
 
   - file: "07-activity-11b.qmd"
     viewof_count: 38

--- a/workflow/validation/day-12-manifest.yml
+++ b/workflow/validation/day-12-manifest.yml
@@ -40,7 +40,7 @@ chapters:
     headings:
       - 'Section 3: "BUT WHAT CAN *I* DO?"'
       - "PAUSE FOR THOUGHT 12–c"
-    has_download_button: false
+    has_download_button: true
 
   - file: "05-leadership-for-the-transformation.qmd"
     viewof_count: 0


### PR DESCRIPTION
## Summary

- Flip `has_download_button: false` → `true` for 10 chapters across Days 2, 10, 11, 12 where the QMD genuinely contains a `createDownloadButton` call. Drift had accumulated as buttons were added in later PRs without bumping the manifests. `scripts/check-structure.sh` only emits these as warnings, so they slid by silently.
- Audited the inverse direction (manifest says `true`, QMD has no button) — found one match, Day 8 `06-major-activity.qmd`, which correctly uses `createCoopDownloadButton`. The validator's regex `create(Coop)?DownloadButton` covers this; manifest stays as `true`.

Closes #271.

## Affected chapters

| Day | Chapter | Was | Is |
| --- | --- | --- | --- |
| 2 | `06-your-turn.qmd` | false | true |
| 2 | `07-some-recollections.qmd` | false | true |
| 2 | `08-major-activity.qmd` | false | true |
| 10 | `02-appreciation-for-a-system.qmd` | false | true |
| 10 | `04-theory-of-variation.qmd` | false | true |
| 11 | `02-theory-of-knowledge-prediction.qmd` | false | true |
| 11 | `03-theory-of-knowledge-theory-and-learning.qmd` | false | true |
| 11 | `04-theory-of-knowledge-operational-definitions.qmd` | false | true |
| 11 | `06-knowledge-of-psychology.qmd` | false | true |
| 12 | `04-but-what-can-i-do.qmd` | false | true |

No QMD content changes — manifests only.

## Test plan

- [x] `./scripts/check-structure.sh N` for N in 1..12 reports zero failures and zero warnings about download buttons.
- [x] Cross-audit script (using the validator's own `create(Coop)?DownloadButton` regex) reports "All in sync."
- [x] `git diff --stat` shows only the 4 manifest files, 10 insertions / 10 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)