### PR TITLE
Reframe README PDF section as site scope (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,11 @@ Each day includes:
 - **Print-Friendly**: Clean, formatted output for printing or PDF generation
 - **Accessibility**: Skip-link, optional dyslexia-friendly font, ARIA-labelled interactive elements, and reduced-motion support — see the [Accessibility](#-accessibility) section below for the full list
 
-### Complete PDF Version
-The full course material is available as free PDF downloads from several sources:
+### Original PDF Source
 
-- **[New Zealand Organisation for Quality (NZOQ)](https://www.nzoq.org.nz/12-days-to-deming)**: Complete course with individual PDF files for each day and the printable Workbook B1–B4 companion
-- **Other Quality Organizations**: Various quality management organizations worldwide offer the course materials
+The course originated as a free PDF set hosted by the **[New Zealand Organisation for Quality (NZOQ)](https://www.nzoq.org.nz/12-days-to-deming)**, which remains the upstream source of record. Several other quality organisations mirror the same material.
 
-The PDF version includes:
-- Welcome booklet and course introduction
-- Individual day materials (Days 1-12)
-- Printable Workbook B1–B4 for hands-on activities (PDF edition only — this site captures the same activities through in-page text inputs)
-- Appendix and reference materials
-- Optional extras and additional resources
-
-**Note**: The NZOQ PDF edition remains the upstream source of record for this course. This site is a respectful interactive rendering of that material; the printed Workbook is exclusive to the PDF edition.
+This site is a respectful interactive rendering of that material — Dr. Neave's text is preserved verbatim; only the presentation has changed. Notably, the original PDF set ships a printable Workbook companion (B1–B4) for hand-written activity answers; this site replaces that flow with in-page text inputs, so there is no equivalent Workbook here. Refer to the NZOQ PDFs directly if you want to cross-reference the print edition.
 
 ### Content Integrity
 **Important Note**: Both the interactive online version and PDF versions preserve Dr. Neave's original content exactly as he wrote it. No changes have been made to his teachings, examples, or explanations. The enhancements focus solely on presentation and user experience—maintaining the authentic learning journey and pedagogical flow that Dr. Neave carefully crafted. The interactive elements are designed to support and amplify his original vision, not replace or modify it.


### PR DESCRIPTION
## Summary

Closes #185. Implements the decisions locked in on the issue:

- **1A** — delete day-chapter `.workbook_callout` boxes
- **2A** — remove the appendix Workbook passages
- **3** — strip the `workbook_callouts` manifest field and check (consequent of 1A)
- **4** — reframe README around site scope, link to NZOQ as needed

## What turned out to need a code change

After auditing the codebase against the issue's scope checklist, **only decision 4 had any live work left.** Decisions 1A, 2A, and 3 were already fully implemented in earlier PRs (the broken-link cleanup in #137 and the Workbook-reference policy in #195/sibling PRs).

| Item | State at audit |
|---|---|
| `.workbook_callout` divs in `content/days/**` | Already absent |
| `.workbook_callout` CSS in `assets/styles/main.css` | Already absent |
| Workbook references in `content/days/**` | Already absent |
| Workbook references in `content/appendix/**` | Already absent |
| `workbook_callouts` field in `workflow/validation/*-manifest.yml` | Already absent |
| Workbook-callout check in `scripts/check-structure.sh` | Already absent |
| `workflow/CONVERSION_GUIDE.md` (per old issue body) | Renamed to `PATTERNS.md` in #265; no Workbook callout references |
| `workflow/day-brief-template.yml` | No Workbook references |
| `workflow/inter-day-refs.csv` | No Workbook references |
| #137 | Already closed |

So the issue's scope checklist was largely a snapshot from before those earlier PRs landed.

## What this PR actually changes

`README.md` — the "Complete PDF Version" subsection enumerated the upstream NZOQ bundle's internals (welcome booklet, day materials, Workbook B1–B4, appendix, optional extras). Per decision 4, that's reframed as "Original PDF Source": a short two-paragraph section that links to NZOQ as the upstream source of record and notes that the printable Workbook is exclusive to the PDF edition (so readers know not to look for it here). Net diff: +3, –12.

## What is intentionally NOT changed

- `workflow/PATTERNS.md` lines 580–596 — historical documentation of how the #195 cleanup pattern was applied. Useful context for anyone wondering why the appendix prose looks the way it does today.
- `workflow/briefs/*-brief.yml` — historical record per `MEMORY.md` ("frozen editorial decisions per day"). Workbook page numbers in these files are descriptions of the source material, not live runtime data.
- `scripts/archive/README_interactive_elements.md` — archived per CLAUDE.md.

## Test plan

- [x] `git diff --stat` confirms README.md is the only changed file
- [x] `grep -n -i "workbook" README.md` shows only the two intentional, site-scoped mentions remaining
- [x] No structural changes (no manifest, content, CSS, JS, or R changes), so `quarto render` and `scripts/check-structure.sh` don't apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)