### PR TITLE
Wire check-structure.sh into CI; promote drift WARNs to FAIL (#274)

### DIFF
--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -6,6 +6,16 @@ permissions:
 on:
   pull_request:
     types: [opened, synchronize]
+    # The structure check only validates QMDs against manifests, plus the
+    # images they reference and the script/workflow themselves. Narrow the
+    # trigger to those paths so unrelated PRs (CSS-only, JS-only, prose
+    # outside content/, etc.) don't burn CI minutes on it.
+    paths:
+      - 'content/**'
+      - 'workflow/validation/**'
+      - 'assets/images/**'
+      - 'scripts/check-structure.sh'
+      - '.github/workflows/structure-check.yml'
   push:
     branches:
       - main

--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -1,0 +1,47 @@
+name: Structure Check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  structure:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1.306.0
+      with:
+        ruby-version: '3.2'
+
+    - name: Run structure checks
+      run: |
+        overall_fail=0
+        for d in $(seq 1 12); do
+          echo "::group::Day $d"
+          ./scripts/check-structure.sh "$d" || overall_fail=1
+          echo "::endgroup::"
+        done
+
+        shopt -s nullglob
+        for manifest in workflow/validation/appendix-*-manifest.yml; do
+          slug=$(basename "$manifest" | sed -E 's/^appendix-(.+)-manifest\.yml$/\1/')
+          echo "::group::Appendix $slug"
+          ./scripts/check-structure.sh --appendix "$slug" || overall_fail=1
+          echo "::endgroup::"
+        done
+
+        exit "$overall_fail"

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -12,9 +12,8 @@
 # download button. Appendix manifests can opt out of interactive checks for
 # prose-only content (set `interactive_checks: false`).
 #
-# Requires: ruby (for YAML parsing — ships with macOS)
-# Note: CI (Ubuntu) does not install Ruby by default. If wiring into CI,
-# add ruby to the workflow's setup steps.
+# Requires: ruby (for YAML parsing — ships with macOS).
+# CI installs it via ruby/setup-ruby in .github/workflows/structure-check.yml.
 
 set -euo pipefail
 
@@ -26,11 +25,10 @@ TMPDIR_CLEANUP=""
 if [[ -t 1 ]]; then
   GREEN='\033[0;32m'
   RED='\033[0;31m'
-  YELLOW='\033[0;33m'
   BOLD='\033[1m'
   RESET='\033[0m'
 else
-  GREEN='' RED='' YELLOW='' BOLD='' RESET=''
+  GREEN='' RED='' BOLD='' RESET=''
 fi
 
 # ── Helpers ───────────────────────────────────────────────────
@@ -49,7 +47,6 @@ usage() {
 
 pass() { printf "  ${GREEN}PASS${RESET} %s\n" "$1"; }
 fail() { printf "  ${RED}FAIL${RESET} %s\n" "$1"; }
-warn() { printf "  ${YELLOW}WARN${RESET} %s\n" "$1"; }
 
 # Expand manifest into a flat text format using Ruby, one file per chapter,
 # plus a top-level `meta` file capturing manifest-wide settings
@@ -195,7 +192,6 @@ main() {
   local total_checks=0
   local total_pass=0
   local total_fail=0
-  local total_warn=0
 
   for ch_file in "$tmpdir"/ch_*; do
     [[ -f "$ch_file" ]] || continue
@@ -329,9 +325,8 @@ main() {
         pass "headings: none expected, none found"
         total_pass=$((total_pass + 1))
       else
-        warn "headings: $actual_hdg_count found but none in manifest"
-        total_pass=$((total_pass + 1))
-        total_warn=$((total_warn + 1))
+        fail "headings: $actual_hdg_count found but none in manifest"
+        total_fail=$((total_fail + 1))
       fi
     fi
 
@@ -348,9 +343,8 @@ main() {
         fi
       else
         if grep -qE 'create(Coop)?DownloadButton' "$qmd_path" 2>/dev/null; then
-          warn "download button: found but not in manifest"
-          total_pass=$((total_pass + 1))
-          total_warn=$((total_warn + 1))
+          fail "download button: found but not in manifest"
+          total_fail=$((total_fail + 1))
         else
           pass "download button: none expected"
           total_pass=$((total_pass + 1))
@@ -372,9 +366,6 @@ main() {
     printf "  Failed:         ${RED}%d${RESET}\n" "$total_fail"
   else
     echo "  Failed:         0"
-  fi
-  if (( total_warn > 0 )); then
-    printf "  Warnings:       ${YELLOW}%d${RESET}  (elements found but not in manifest)\n" "$total_warn"
   fi
   echo ""
 


### PR DESCRIPTION
## Summary

Closes #274. Three changes that together make manifest drift impossible to merge silently:

1. **New `.github/workflows/structure-check.yml`** — installs Ruby via `ruby/setup-ruby` (SHA-pinned to `v1.306.0` matching the repo's SHA-pin convention) and loops `scripts/check-structure.sh` against every day 1–12 and every `appendix-*-manifest.yml`. Triggers on PR + push to main, mirroring `accessibility.yml`.
2. **Download-button drift WARN → FAIL** in `scripts/check-structure.sh` — the original trigger for the issue.
3. **Heading drift WARN → FAIL** by the same logic, plus removal of dead WARN infrastructure now that no warning paths remain.

## Why both WARN paths got promoted

The original issue called out the download-button WARN explicitly and asked "audit the other WARN paths in the script." There was one other: heading drift at the line that fired when a chapter had `## ` headings that the manifest didn't list. Keeping it WARN would have left exactly the asymmetry that bit Day 12 in #160 — fail loudly when a manifest heading was absent from source, but only whisper when source headings were absent from the manifest. Promoting both keeps the rule symmetric: **manifest and source must agree**, full stop.

With both WARN call-sites gone, the supporting infrastructure (`warn()` helper, `total_warn` accumulator, `YELLOW` colour, the warnings line in the summary) is dead. Removed for clarity — easier to add back when a real WARN-level need surfaces than to keep a misleading three-state model alive in the meantime.

## Behaviour change for contributors

Before: drift accumulated silently; `WARN` lines in local runs got scrolled past.
After: pushing manifest drift fails CI before merge. No new local-only step required of contributors.

## CI loop strategy

The job accumulates failures across all 14+ manifests rather than fast-failing on the first broken day. CI minutes are cheap; getting one report that surfaces every drifted day at once beats discovering them across multiple PR pushes.

## Verification

Ran the modified script locally against every day 1–12 plus `appendix-contributions-balaji-reddie` after the WARN→FAIL flip — all pass with zero failures. So this PR turns on the gate without surfacing any latent drift that needs separate cleanup.

## Test plan

- [x] `ruby -ryaml -e 'YAML.safe_load(File.read(ARGV[0]))' .github/workflows/structure-check.yml` confirms the workflow YAML parses
- [x] `./scripts/check-structure.sh N` for N in 1..12 — all green
- [x] `./scripts/check-structure.sh --appendix contributions-balaji-reddie` — green
- [x] Exit code is 0 on a passing day (preserves existing CI semantics)
- [ ] CI run on this PR (will validate Ruby-on-Ubuntu setup + the workflow itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)