### PR TITLE
Author appendix-main and appendix-optional-extras manifests (#280)

### DIFF
--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -268,12 +268,14 @@ main() {
       total_pass=$((total_pass + 1))
     fi
 
-    # Check all ![...](path) refs in QMD point to existing files
-    # Use Ruby for reliable parsing — regex alone can't handle parentheses in alt text
+    # Check all ![...](path) refs in QMD point to existing files.
+    # The alt-text group allows one level of balanced [...] nesting so that
+    # Pandoc image alts containing inline markdown links (e.g. ![text with
+    # [link](anchor)](real-url)) parse correctly.
     local qmd_figs
     qmd_figs=$(ruby -e '
       ARGF.each_line do |line|
-        line.scan(/!\[[^\]]*\]\(([^)]+)\)/) { |m| puts m[0] }
+        line.scan(/!\[(?:[^\[\]]|\[[^\]]*\])*\]\(([^)]+)\)/) { |m| puts m[0] }
       end
     ' "$qmd_path" 2>/dev/null | sed 's/%20/ /g' || true)
     if [[ -n "$qmd_figs" ]]; then

--- a/workflow/validation/appendix-main-manifest.yml
+++ b/workflow/validation/appendix-main-manifest.yml
@@ -1,0 +1,132 @@
+# Appendix structural manifest: main Appendix (Discussions and Information)
+# Source PDF: P.Appendix.09Feb22.pdf
+#
+# Covers the Glossary plus the 12 main appendix files (00-welcome through
+# 11-references-and-sources). All chapters are prose-only — no `viewof`
+# inputs, no download buttons — so interactive_checks is false and only
+# heading and figure-reference checks run.
+#
+# Per-chapter figures lists are intentionally empty: the script also walks
+# every ![](path) ref in each QMD and verifies it on disk, so the manifest
+# stays focused on headings (the structural anchor we control directly).
+#
+# The two sub-appendices that branch off from this one have their own
+# manifests:
+#   - workflow/validation/appendix-optional-extras-manifest.yml
+#   - workflow/validation/appendix-contributions-balaji-reddie-manifest.yml
+
+slug: main
+pdf_file: P.Appendix.09Feb22.pdf
+content_dir: content/appendix
+interactive_checks: false
+
+chapters:
+  - file: "glossary.qmd"
+    figures: []
+    headings:
+      - "common cause / common-cause variation"
+      - "in statistical control"
+      - "operational definition"
+      - "PDSA cycle (Plan-Do-Study-Act)"
+      - "special cause / special-cause variation"
+      - "System of Profound Knowledge"
+      - "transformation"
+
+  - file: "00-welcome.qmd"
+    figures: []
+    headings:
+      - 'RECOMMENDED "OUT-OF-HOURS" PREPARATION'
+
+  - file: "01-day-1.qmd"
+    figures: []
+    headings:
+      - "PAUSE FOR THOUGHT 1–c"
+      - "MAJOR ACTIVITY 1–f"
+
+  - file: "02-day-2.qmd"
+    figures: []
+    headings:
+      - "PAUSE FOR THOUGHT 2–b"
+      - "PAUSE FOR THOUGHT 2–c"
+      - "PAUSE FOR THOUGHT 2–e"
+      - "ACTIVITY 2–f"
+      - "ACTIVITY 2–g"
+      - "Technical Aid 4"
+      - "MAJOR ACTIVITY 2–h"
+      - 'Dave Kerr''s "Wrap-Up Brief" following the Red Beads Experiment'
+
+  - file: "03-day-3.qmd"
+    figures: []
+    headings:
+      - "ACTIVITY 3–b"
+      - "ACTIVITY 3–g"
+      - "MAJOR ACTIVITY 3–h"
+      - "ACTIVITY 3–i"
+      - "ACTIVITY 3–j"
+
+  - file: "04-day-4.qmd"
+    figures: []
+    headings:
+      - "ACTIVITY 4–a"
+      - "ACTIVITY 4–d"
+      - "ADDENDA TO POINTS 1 AND 3"
+
+  - file: "05-day-5.qmd"
+    figures: []
+    headings:
+      - "Point 7. Institute leadership of people *([Day 5 pages 2–3](../days/day-05/02-points-7-to-14.qmd#sec-page2))*"
+      - "Point 8. Drive out fear *([Day 5 pages 4–5](../days/day-05/02-points-7-to-14.qmd#sec-page4))*"
+      - "Point 9. Break down barriers *([Day 5 pages 6–7](../days/day-05/02-points-7-to-14.qmd#sec-page6))*"
+      - "Point 10. Eliminate exhortations *([Day 5 pages 8–9](../days/day-05/02-points-7-to-14.qmd#sec-page8))*"
+      - "Point 11. Eliminate arbitrary numerical targets *([Day 5 pages 10–11](../days/day-05/02-points-7-to-14.qmd#sec-page10))*"
+      - "Point 12. Permit pride of workmanship *([Day 5 pages 12–13](../days/day-05/02-points-7-to-14.qmd#sec-page12))*"
+      - "Point 13. Encourage education *([Day 5 pages 14–15](../days/day-05/02-points-7-to-14.qmd#sec-page14))*"
+      - "Point 14. Top management commitment and action *([Day 5 pages 16–17](../days/day-05/02-points-7-to-14.qmd#sec-page16))*"
+      - "Disease 1. Lack of constancy *([Day 5 pages 18–19](../days/day-05/03-the-deadly-diseases.qmd#sec-page18))*"
+      - "Disease 2. Short-termism *([Day 5 pages 20–21](../days/day-05/03-the-deadly-diseases.qmd#sec-page20))*"
+      - "Disease 3. Appraisal of performance *([Day 5 pages 22–23](../days/day-05/03-the-deadly-diseases.qmd#sec-page22))*"
+      - "Disease 4. Management job-hopping *([Day 5 pages 24–25](../days/day-05/03-the-deadly-diseases.qmd#sec-page24))*"
+      - "Disease 5. Use of only visible figures *([Day 5 pages 26–27](../days/day-05/03-the-deadly-diseases.qmd#sec-page26))*"
+
+  - file: "06-day-7.qmd"
+    figures: []
+    headings:
+      - "ACTIVITY 7–a"
+      - "TRANSCRIPT OF LETTER"
+      - "MORE ON TARGETS IN GOVERNMENT"
+      - "MAJOR ACTIVITY 7–i"
+
+  - file: "07-day-9.qmd"
+    figures: []
+    headings:
+      - "ACTIVITY 9–c"
+      - "MAJOR ACTIVITY 9–e"
+
+  - file: "08-day-10.qmd"
+    figures: []
+    headings:
+      - "ACTIVITY 10–a"
+      - "ACTIVITY 10–b"
+
+  - file: "09-day-11.qmd"
+    figures: []
+    headings:
+      - "ACTIVITY 11–a"
+      - "ACTIVITY 11–b"
+
+  - file: "10-optional-extras.qmd"
+    figures: []
+    headings:
+      - "Introduction"
+      - '"SIX-SIGMA" SUPERSTITIONS'
+      - 'An Alternative "Truth"'
+      - "Superstitions"
+      - "Approvals, Acknowledgments and Information"
+
+  - file: "11-references-and-sources.qmd"
+    figures: []
+    headings:
+      - "BOOKS"
+      - "BOOKLETS"
+      - "VIDEOS / DVDs"
+      - "INTERNET CONTACTS AND ADDRESSES"

--- a/workflow/validation/appendix-optional-extras-manifest.yml
+++ b/workflow/validation/appendix-optional-extras-manifest.yml
@@ -1,0 +1,83 @@
+# Appendix structural manifest: Optional Extras
+# Source PDF: S.Optional.Extras.09Jul21.pdf
+#
+# Seven-chapter reference appendix (Introduction + Parts A-F) on
+# statistical foundations and control-chart theory. All chapters are
+# prose-only — no `viewof` inputs, no download buttons — so
+# interactive_checks is false and only heading and figure-reference
+# checks run.
+#
+# Parts A and B render OJS-driven plots, but no `viewof` inputs.
+# Parts D, E, F carry stable per-page anchors (see brief) which the
+# heading check enforces by way of the trailing {#sec-...} attribute
+# strip in scripts/check-structure.sh.
+#
+# Per-chapter figures lists are intentionally empty: the script also
+# walks every ![](path) ref in each QMD and verifies it on disk, so
+# the manifest stays focused on headings.
+
+slug: optional-extras
+pdf_file: S.Optional.Extras.09Jul21.pdf
+content_dir: content/appendix/optional-extras
+interactive_checks: false
+
+chapters:
+  - file: "00-introduction.qmd"
+    figures: []
+    headings:
+      - "Contents"
+      - "NOTE"
+      - "INTRODUCTION"
+
+  - file: "01-part-a-funnel-charts.qmd"
+    figures: []
+    headings:
+      - "1. Introduction"
+      - "2. Rules 1 and 2 of the Funnel"
+      - "Draw your own Rule 1 and Rule 2 charts"
+      - "3. Rules 3 and 4 of the Funnel"
+      - "4. Control charts for the computer-generated data"
+      - "5. Discussion"
+
+  - file: "02-part-b-subgrouped.qmd"
+    figures: []
+    headings:
+      - "1. Introduction"
+      - "2. Calculations on a subgroup"
+      - "3. Control charts for subgrouped data"
+      - "4. Discussion"
+
+  - file: "03-part-c-ne-er-twain.qmd"
+    figures: []
+    headings:
+      - "1. Introduction"
+      - "2. The essence of the argument"
+
+  - file: "04-part-d-crash-course.qmd"
+    figures: []
+    headings:
+      - "Histograms and sample statistics"
+      - "Probability"
+      - "Linking it all together"
+      - "Probability distributions, particularly the binomial distribution"
+      - "Continuous probability distributions, particularly the normal distribution"
+      - "The Central Limit Theorem"
+      - "Confidence intervals"
+      - "Hypothesis tests (also known as significance tests or tests of significance)"
+
+  - file: "05-part-e-normality.qmd"
+    figures: []
+    headings:
+      - "1. Back to basics"
+      - "2. Two simulation studies"
+      - '3. "Control-chart constants depend on normally-distributed data, so unless your data are normally distributed your control chart isn''t valid."'
+      - '4. "If your data are normally distributed then the probability of a false signal is 0.0027"'
+
+  - file: "06-part-f-technical.qmd"
+    figures: []
+    headings:
+      - "1. Length of the baseline"
+      - '2. "Expected" values — the great misnomer!'
+      - "3. Proofs and uses of expected values"
+      - "4. Why are control-chart constants what they are?"
+      - "5. More on the binomial and normal distributions"


### PR DESCRIPTION
## Summary

Closes the structure-check coverage gap on the 19 appendix QMDs / ~3,050 lines that previously had no CI gating against silent regression. Two new manifests:

- `workflow/validation/appendix-main-manifest.yml` — Glossary + 12 main appendix files (00-welcome through 11-references-and-sources). 38 checks, all PASS.
- `workflow/validation/appendix-optional-extras-manifest.yml` — Introduction + Parts A–F. 61 checks, all PASS.

Both mirror the existing Balaji Reddie manifest shape:
- `interactive_checks: false` (no `viewof` inputs, no download buttons in any appendix QMD).
- `figures: []` per chapter — the script also walks every `![](path)` ref in the QMD and verifies it on disk, so the manifest stays focused on headings (the structural anchor we control authoritatively).
- Header commentary on each manifest explains the prose-only mode and the figure-check delegation.

No workflow change needed — `.github/workflows/structure-check.yml` already loops `appendix-*-manifest.yml` so the new manifests get picked up automatically.

## Bonus fix: script regex bug surfaced during validation

`scripts/check-structure.sh` mis-parsed Pandoc image alts that contain inline markdown links. The original alt-text group `[^\]]*` doesn't allow `]` inside, so on `01-part-a-funnel-charts.qmd:71,75` (which embed `[Day 3 page 19](anchor)` inside their alt text) the parser captured the inner anchor URL instead of the real image path and reported phantom broken refs.

Fix: `(?:[^\[\]]|\[[^\]]*\])*` — allows one level of balanced `[...]` nesting in the alt-text group. Kept non-capturing so the URL stays at `m[0]` and the rest of the script is untouched. Only those two lines in the entire repo have nested-link alts, so this is purely a correctness fix; all 12 Days + Reddie still PASS afterward.

## Resolves

Closes #280.

## Test plan

- [x] `./scripts/check-structure.sh --appendix main` → 38/38 PASS
- [x] `./scripts/check-structure.sh --appendix optional-extras` → 61/61 PASS
- [x] `./scripts/check-structure.sh --appendix contributions-balaji-reddie` → still PASS (regression check on existing manifest)
- [x] `./scripts/check-structure.sh 1` … `12` → all 12 Days still PASS (regression check on existing day manifests)
- [ ] CI `Structure Check` workflow picks up both new manifests on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)