### PR TITLE
Layout: float right-aligned images, stack columns on mobile

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -246,6 +246,22 @@ Usage:
   }
 }
 
+/* Quarto's `.columns` is a flex grid with no built-in mobile breakpoint — a
+   `width="30%"` column stays at 30% on a 390px phone, crushing the text
+   column and stretching whitespace below short images/charts. Stack to
+   single-column at the same 700px breakpoint as `.float-box` for a
+   consistent responsive boundary across the site. `!important` is required
+   to override Quarto's inline `style="width: ..."` on each child column,
+   and to win against Quarto's bundled `display: flex` on `.columns`. */
+@media (max-width: 700px) {
+  .columns {
+    display: block !important;
+  }
+  .columns > .column {
+    width: 100% !important;
+  }
+}
+
 /* ===== CONTENT STYLES ===== */
 .neave_note {
   text-align: left;
@@ -622,8 +638,13 @@ button:focus,
   outline-offset: 2px;
 }
 
-/* High contrast mode */
-@media (prefers-contrast: high) {
+/* High contrast mode. The standardised values for `prefers-contrast` are
+   `no-preference | more | less | custom` — the legacy draft values
+   `high`/`low` were dropped during standardisation and Firefox treats them
+   as invalid, silently skipping the whole rule. Use `more` so the
+   high-contrast overrides actually fire when a user has requested
+   "increase contrast" at the OS level. */
+@media (prefers-contrast: more) {
   .deming_quote {
     color: #000080;
     font-weight: bold;

--- a/content/days/day-01/02-rediscovered.qmd
+++ b/content/days/day-01/02-rediscovered.qmd
@@ -7,27 +7,18 @@ execute:
   
 ## The Deming Prize and the Nashua Corporation {#sec-page2}
 
-:::: {.columns}
+<div class="float-box-right">
 
-::: {.column width="70%"}
+![William E Conway](/assets/images/day-01/day_1_fig_2.png){.lightbox}
+
+</div>
+
 In the 1970s, a medium-sized American company, the Nashua Corporation, was
 an agent for copying machines made by Ricoh, the well-known Japanese manufacturer. In 1974, Ricoh was awarded Japan’s Deming Prize. The people at
 Nashua, including Chief Executive William E Conway, did not know who or what
 “Deming” was. All they knew was that the illustrious and eagerly-sought Deming
 Prize was Japan’s best-known award for quality, and had been set up as long ago
 as 1950 by JUSE, the Japanese Union of Scientists and Engineers.
-:::
-  
-::: {.column width="5%"}
-
-:::
-  
-::: {.column width="25%"}
-![William E Conway](/assets/images/day-01/day_1_fig_2.png){.lightbox}
-
-:::
-  
-::::
   
   ![The Deming Medal, showing a profile of W. Edwards Deming with the inscription 'The right quality and uniformity are foundations of commerce, prosperity and peace.'](/assets/images/day-01/day_1_fig_3.jpg){width=50% .lightbox}
 
@@ -37,9 +28,11 @@ The inscription near the bottom of the medal[^a] is a quotation from Dr Deming:
   
 <span class=neave_note>NB Throughout this course, exact quotations from Dr Deming are printed in blue in order to set them apart from my own writing. His own quotations are especially valuable in that he had the rare ability of being able to say a very great deal in remarkably few words. I wouldn’t want to mislead you into thinking that I am capable of the same degree of either brevity or wisdom!</span>
   
-:::: {.columns}
+<div class="float-box-right">
 
-::: {.column width="70%"}
+![Dr Lloyd S Nelson](/assets/images/day-01/day_1_fig_4.png){.lightbox}
+
+</div>
 
 Almost five more years passed before Bill Conway discovered that this “Deming” was in fact an American,
 Dr W Edwards Deming who, although already in his late 70s, was still actively
@@ -50,18 +43,6 @@ concerning events ranging over the previous 30 and more years, the content of
 which Bill found extraordinary and initially almost unbelievable. Eventually, Bill
 persuaded Dr Deming to become a consultant for Nashua—although I suggest
 a “teacher” would have been a better description.
-
-:::
-  
-::: {.column width="5%"}
-
-:::
-  
-::: {.column width="25%"}
-![Dr Lloyd S Nelson](/assets/images/day-01/day_1_fig_4.png){.lightbox}
-:::
-  
-::::
   
 One of Dr Deming’s first recommendations was that Nashua acquire the services of an experienced statistician. On Deming’s advice, Bill “head-hunted”
 Dr Lloyd S Nelson, who at that time had been working in the General Electric
@@ -70,9 +51,12 @@ because, although we had never met, I had been in correspondence with Lloyd for 
 1970. A short while after moving to Nashua, Lloyd contacted me to ask if I would be interested in getting
 involved with Nashua’s British subsidiaries. I accepted the invitation.
 
-:::: {.columns}
+<div class="float-box-right">
 
-::: {.column width="70%"}
+![Dr Walter A Shewhart](/assets/images/day-01/day_1_fig_5.png){.lightbox}
+
+</div>
+
 My main initial task was to help set up and supervise a company-wide
 training scheme, mostly on some of what are often referred to as the “old
 tools” or “seven tools” of quality. Lloyd’s syllabus included the Ishikawa
@@ -85,17 +69,6 @@ basics will just be “optional extras” for those who are really interested in
 them. Later today we shall also see an extremely important illustration
 which Deming referred to as a “flow diagram”, but that’s not quite the
 same as what most people mean by “flowcharting”.
-:::
-  
-::: {.column width="5%"}
-
-:::
-  
-::: {.column width="25%"}
-![Dr Walter A Shewhart](/assets/images/day-01/day_1_fig_5.png){.lightbox}
-:::
-  
-::::
   
 ## The four-day seminars
   

--- a/content/days/day-01/05-activities.qmd
+++ b/content/days/day-01/05-activities.qmd
@@ -10,7 +10,7 @@ the same way, in this course I shall ask you to do much more than just read what
 *only* to read then please content yourself with one or more of the books I have just mentioned. But this
 course is for *active* learning, and that is quite different from merely reading.
 
-**If you have so far not read the “Welcome to *12 Days to Deming*” in the “A. PLEASE START HERE” file then please “stop the clock” and do so before continuing here. It contains lots of necessary information and good advice!**
+**If you have so far not read the [“Welcome to *12 Days to Deming*”](../../../index.qmd) in the “A. PLEASE START HERE” file then please “stop the clock” and do so before continuing here. It contains lots of necessary information and good advice!**
 
 So on every Day of this course I shall from time to time ask you to stop and do something—let’s call it a
 “request for action”. At one extreme the request may simply be for you to spend just a few minutes thinking about something and jotting down a few relevant notes: I’m calling this a “Pause for Thought”. When

--- a/content/days/day-01/11-deming-story.qmd
+++ b/content/days/day-01/11-deming-story.qmd
@@ -169,9 +169,12 @@ the end of the Second World War, was primarily to work with the Japanese Census.
 
 Does that heading seem familiar? I’ll remind you a little later of where you first saw it.
 
-:::: {.columns}
+<div class="float-box-right">
 
-::: {.column width=55%}
+![Ken-ichi Koyanagi with Dr Deming](/assets/images/day-01/day_1_fig_6.png){.lightbox}
+
+</div>
+
 A further visit to Japan, again to work with the Census, was planned for the early summer of 1950. By this
 time, Dr Deming’s name and reputation had become known to Ken-ichi Koyanagi, Managing Director of the
 Union of Japanese Scientists and Engineers. Accordingly, Koyanagi issued the all-important invitation for Dr Deming to also teach
@@ -179,22 +182,9 @@ concepts and methods for the achievement of quality in *industry*.
 During that visit, his teaching not only reached hundreds of engineers, plant managers, research workers, and so on, but it also
 reached *top management*. A particularly famous meeting was
 held in July 1950 with the 21 top industrialists of the country present, a meeting later described as the occasion at which Dr Deming
-had in that one room " *80% of the industrial capital in Japan right there in front of him*. Deming regarded that as his breakthrough: that the *top* people came to listen and learn from him.                                                                           
+had in that one room " *80% of the industrial capital in Japan right there in front of him*. Deming regarded that as his breakthrough: that the *top* people came to listen and learn from him.
 
-:::
-
-::: {.column width=5%}
-
-:::
-
-::: {.column width=40%}
-
-![Ken-ichi Koyanagi with Dr Deming](/assets/images/day-01/day_1_fig_6.png){.lightbox}
-
-:::
-
-::::
-                                                                                           But there was another important reason why the Japanese listened to, and learned from, Deming. Koyanagi expressed it well on page 8 of *The Deming Prize* (1960):
+But there was another important reason why the Japanese listened to, and learned from, Deming. Koyanagi expressed it well on page 8 of *The Deming Prize* (1960):
 
 >“Most of the Japanese were in a servile spirit as the vanquished, and among Allied personnel there were not a few with an air of importance <span class=neave_note>[which I imagine was something of an understatement]</span>. In striking contrast, Dr Deming showed his warm cordiality to every Japanese whom he met. ... His high personality deeply impressed all those who learned from him and became acquainted with him. ... The sincerity and enthusiasm with which he did his best for us still lives and will live forever in the memory of all concerned.”
 

--- a/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
+++ b/content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd
@@ -13,14 +13,13 @@ To help discover the messages, members of the audience are invited to adopt a du
 
 So the All-Knowing, looking down at the system from on high, has full comprehension of it. But to the Un-Knowing, looking up at it from floor level, it is far too large and complex for him to have any chance of understanding what is happening. Nevertheless, our Un-Knowing does have a brain—a rather special brain for an insect! Let us suppose that the Un-Knowing can recognise numbers, and can interpret them just as well as the average manager, politician, media reporter—or maybe even economist or accountant!
 
-:::: {.columns}
-::: {.column width="55%"}
+<div class="float-box-right">
+
+![Red Beads Experiment apparatus: a red box with white and red beads, and a paddle with circular depressions.](/assets/images/day-02/image-4.jpg){.lightbox}
+
+</div>
+
 Going by what they see, the delegates will more naturally identify with the "All-Knowing" role. The apparatus for the experiment is most surely <span class="deming_quote">"stupidly simple"</span>. There is a container half-filled with a large number of beads, differing only (as far as one can tell) in colour. 3,000 of the beads are white and the remaining 750 are red. Then there is a piece of wood or plastic: the so-called "paddle". The paddle has 50 circular depressions sunk into it in a 5 × 10 pattern. There is also a bucket to help in a mixing operation. The only other apparatus provided is pens and paper and a couple of clipboards for the convenience of the junior inspectors.
-:::
-::: {.column width="45%"}
-![Red Beads Experiment apparatus: a red box with white and red beads, and a paddle with circular depressions.](/assets/images/day-02/image-4.jpg){fig-align="left" width="100%" style="float: left; margin-right: 1em; margin-bottom: 1em;"}
-:::
-::::
 
 ## The training, part 1
 

--- a/content/days/day-06/02-gallery-furniture.qmd
+++ b/content/days/day-06/02-gallery-furniture.qmd
@@ -6,19 +6,13 @@ execute:
 
 ## Gallery Furniture {#sec-page6}
 
-:::: {.columns}
+<div class="float-box-right">
 
-::: {.column width="70%"}
-The first time I learned anything of Gallery Furniture was at a four-day seminar held at Newport Beach, California (just south of Los Angeles) in August 1991. You could hardly miss the Gallery Furniture personnel: they had arrived there early enough to bag all the central seats in the front row of the auditorium—between 15 and 20 places as I recall. Then they sat, all dressed alike, wearing maroon-coloured tee-shirts displaying the single word "GALLERY" in large letters.
-:::
-
-::: {.column width="30%"}
-<div class="float-box-content">
 ![Mack McIngvale](/assets/images/day-06/mack-mcingvale.png){.lightbox}
-</div>
-:::
 
-::::
+</div>
+
+The first time I learned anything of Gallery Furniture was at a four-day seminar held at Newport Beach, California (just south of Los Angeles) in August 1991. You could hardly miss the Gallery Furniture personnel: they had arrived there early enough to bag all the central seats in the front row of the auditorium—between 15 and 20 places as I recall. Then they sat, all dressed alike, wearing maroon-coloured tee-shirts displaying the single word "GALLERY" in large letters.
 
 Early during the second morning of the seminar, Dr Deming invited the founder and owner of Gallery Furniture, Jim McIngvale ("Mack"), up onto the stage to tell his story. I listened, amazed and excited by what I heard. Remember, this was back in 1991 when any kind of "Deming movement" in Britain was still pretty young: by then there had still been very few substantive "success stories" to relate—and certainly nothing like this! At the coffee-break which followed, I was one of the dozens who made their way over to Mack to talk to him, congratulate him, and to ask him questions. I had two particular questions for him. First, did he have any write-up of his story that I could bring back home to share with my friends and colleagues? And second, would he come over to Britain and speak to the British Deming Association's Annual Conference? The answer to the first question was No; but instead Mack gave me a video of the first time Dr Deming had invited him to tell his story to a seminar audience, just one month earlier. From then on I repeatedly used that video in my seminars. And Mack came over on two occasions to speak at BDA conferences, first in 1993 and then in 1999.
 


### PR DESCRIPTION
## Summary

Eliminates the tall whitespace gap below right-aligned images on desktop and the squeezed-text-column problem on mobile, plus a drive-by accessibility fix and a couple of small cleanups surfaced during the same audit.

### Layout changes

**Pattern A — convert text-with-image `.columns` blocks to `.float-box-right` (5 sites + the Koyanagi pilot):**

- `content/days/day-01/02-rediscovered.qmd` × 3 (Conway, Lloyd Nelson, Walter Shewhart portraits)
- `content/days/day-01/11-deming-story.qmd` × 1 (Ken-ichi Koyanagi with Dr Deming — earlier pilot)
- `content/days/day-02/05-the-truth-the-whole-truth-and-nothing-but.qmd` × 1 (Red Beads apparatus)
- `content/days/day-06/02-gallery-furniture.qmd` × 1 (Mack McIngvale portrait)

The reason `.columns` produced the gap: it's a Bootstrap-style flex grid where the two children are independent boxes — once the image's box ends, the text's box keeps going *inside its narrower 70% column*, never reclaiming the right-hand space. A real CSS `float: right` lets text reflow past the image and continue at full width below.

**Pattern B — add a mobile-only stacking rule for all `.columns` blocks (`assets/styles/main.css`):**

```css
@media (max-width: 700px) {
  .columns { display: block !important; }
  .columns > .column { width: 100% !important; }
}
```

Quarto's `.columns` has no built-in mobile breakpoint — a `width="30%"` column stays at 30% even on a 390px iPhone. This rule fixes 20 remaining sequential pedagogical pairs that *shouldn't* become floats (Day 2 run charts Months 3–10, Day 2 statisticians' weekly data tables, Day 3 sales control chart, etc.) because each text/chart pair must stay associated. Same 700px breakpoint as the existing `.float-box` rule for a consistent responsive boundary.

### Drive-by fixes

- **`prefers-contrast: high` → `prefers-contrast: more`** (`main.css:642`). The legacy draft value `high` is silently skipped by Firefox, leaving the high-contrast overrides inactive — see #298 (opened separately during the same audit). One-line a11y win.
- **day-02/05 apparatus image:** drop confused inline `style="float: left"` that was a no-op inside `.columns`; add `.lightbox` for click-to-enlarge consistency with other floated portraits.
- **day-06/02 Mack portrait:** remove `<div class="float-box-content">` wrapper (the bordered/background callout style is for boxed asides, not faces — other portraits are bare).
- **day-01/05** (one line): hyperlink the "Welcome to *12 Days to Deming*" reference to `index.qmd`. Pre-existing edit in the working tree from before the layout audit; included to avoid leaving a stranded change.

## Related issues

- Discovered during the same audit and opened as separate items:
  - #298 — Dead classic-script load of `functions.js` (severity: low)
  - #299 — CSP `font-src 'self'` blocks anchorjs-icons + Cosmo Google Fonts (severity: medium)
  - #300 — Replace Excalidraw iframe on Day 2 page 5 (auto-anchor + drawing-pad rethink, severity: medium)
- The `prefers-contrast` change in this PR resolves the third of those audit findings inline (no separate issue).

## Test plan

- [ ] `quarto preview` renders successfully with no errors.
- [ ] **Day 1 → "Deming (Re)discovered":** Conway / Lloyd Nelson / Walter Shewhart each float to the right of their paragraph; the next heading or paragraph reclaims full width below the portrait.
- [ ] **Day 1 → "1950s–1960s: 'The theory of a system, and cooperation'":** Ken-ichi Koyanagi portrait floats right; the "But there was another important reason…" paragraph and following blockquote sit below the image's clear point at full width.
- [ ] **Day 2 → "The truth, the whole truth…":** Red Beads apparatus image floats right at the top of the section; clicking enlarges via the lightbox.
- [ ] **Day 6 → "Gallery Furniture":** Mack's portrait floats right *without* a heavy bordered frame.
- [ ] **Mobile (DevTools responsive mode at <700px wide, e.g. iPhone 12 Pro 390px):**
  - Floated portraits stack full-width above their paragraph (no compressed text column).
  - Day 2 → run charts (Months 3–10) stack vertically: each month's commentary reads above its chart, no squeezed text column.
  - Day 2 → professional statisticians' weekly result tables (Weeks 1–4) stack image-then-textarea.
  - Day 3 → sales data control chart stacks below its commentary.
- [ ] **High-contrast OS setting** (macOS: System Settings → Accessibility → Display → "Increase contrast"; Windows: Settings → Ease of Access → High Contrast): in Firefox, the `.deming_quote` and `.thought` overrides now apply (they previously did not).
- [ ] No regression on existing layouts that already use `.float-box`/`.float-box-right` (Day 7 OFSTED clipping, Day 2 brief overview, Day 2 Willing Workers results image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)