### PR TITLE
Console: drop dead functions.js script + allow data: font-src for anchorjs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -188,7 +188,7 @@ format:
       dark: darkly
     css: assets/styles/main.css
     header-includes: |
-      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://excalidraw.com; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net;">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src https://excalidraw.com; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net;">
       <script>
         (function () {
           try {
@@ -198,7 +198,6 @@ format:
           } catch (e) {}
         })();
       </script>
-      <script src="/assets/scripts/functions.js"></script>
       <script src="/assets/scripts/reading-prefs.js"></script>
       <script>
         document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
## Summary
- **#298** — remove dead classic-script load of `functions.js`. The file is module-only (`export function ...`); the `<script src="...">` tag in `_quarto.yml` was throwing `Uncaught SyntaxError` on every page load. The OJS `import` path used by every callsite is unaffected.
- **#299** — add `data:` to `font-src` in the CSP. Unblocks anchorjs's inline base64 icon font, restoring the `#` glyph that appears next to section headings on hover (an accessibility affordance).
- Google Fonts (Source Sans Pro + Lato) intentionally remain blocked — the typography-hosting decision (allow Google Fonts vs self-host woff2) is tracked separately as #302.

Closes #298, #299. Follow-up: #302.

## Test plan
- [x] No `Uncaught SyntaxError: export declarations may only appear at top level of a module functions.js:1:1` in browser console on a freshly-loaded chapter page.
- [x] No `Content-Security-Policy: ... blocked at data:n/a;base64,...` (anchorjs font) warning.
- [ ] Section heading hover shows a `#` anchor glyph (verify visually on any chapter page).
- [ ] Download button on a Day 1 activity page (e.g. `07-quality-theory` or `13-major-activity`) still produces a `.txt` file when clicked.
- [ ] Google Fonts CSP blocks remain (expected — see #302).

🤖 Generated with [Claude Code](https://claude.com/claude-code)