### PR TITLE
CI: regenerate inter-day-refs.csv on every push and fail on diff

### DIFF
--- a/.github/workflows/interday-audit.yml
+++ b/.github/workflows/interday-audit.yml
@@ -1,0 +1,66 @@
+name: Inter-Day Audit
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Only re-run when something that could change the CSV is touched: the qmd
+    # corpus (concrete + appendix-page + fuzzy refs all live there), the script
+    # itself, or the committed CSV.
+    paths:
+      - 'content/**/*.qmd'
+      - '*.qmd'
+      - 'scripts/build-interday-audit.R'
+      - 'workflow/inter-day-refs.csv'
+      - '.github/workflows/interday-audit.yml'
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Opt r-lib/actions into Node 24 ahead of the Sept 2026 Node 20 removal.
+# Remove once r-lib publishes a v3 tag that runs on Node 24 natively.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+    - name: Setup R
+      uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e  # v2
+      with:
+        r-version: '4.5.1'
+        use-public-rspm: true
+
+    # The audit script only needs a small slice of the renv lockfile (no
+    # rendering, no plotting). Install those packages directly from the public
+    # RSPM binaries instead of restoring the full renv — this keeps cold-start
+    # under a minute and avoids the system-dep matrix that build/deploy needs.
+    - name: Install audit script dependencies
+      shell: Rscript {0}
+      run: |
+        install.packages(c(
+          "fs", "purrr", "readr", "stringr", "tibble", "tidyr", "dplyr"
+        ))
+
+    - name: Regenerate inter-day audit CSV
+      run: Rscript scripts/build-interday-audit.R
+
+    - name: Verify CSV is in sync with content
+      run: |
+        if ! git diff --exit-code workflow/inter-day-refs.csv; then
+          echo ""
+          echo "::error::workflow/inter-day-refs.csv is out of sync with content."
+          echo "::error::Run 'Rscript scripts/build-interday-audit.R' locally and commit the updated CSV."
+          exit 1
+        fi

--- a/.github/workflows/interday-audit.yml
+++ b/.github/workflows/interday-audit.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #281.

## Summary
- New workflow `.github/workflows/interday-audit.yml` runs on PRs that touch qmd content (or the script/CSV themselves) and on pushes to main.
- It re-runs `Rscript scripts/build-interday-audit.R` against the current tree, then `git diff --exit-code workflow/inter-day-refs.csv` — failing the job if the committed CSV has drifted from content.
- The error message tells the contributor exactly which command to run locally.

## Implementation choice
- Used **Option B** (separate workflow) per the issue's fallback. `structure-check.yml` is currently Ruby-only; bolting R onto it would inflate its scope.
- Skipped full `renv::restore()` and instead direct-installs the seven packages the script actually uses (`fs`, `purrr`, `readr`, `stringr`, `tibble`, `tidyr`, `dplyr`) from public RSPM binaries. Keeps cold-start under a minute and avoids re-litigating the system-dep matrix that `deploy.yml` maintains. Tidyverse APIs the script touches are stable; `deploy.yml` continues to validate the canonical pinned versions.

## Test plan
- [x] Baseline check: regenerated CSV locally — clean diff against committed `workflow/inter-day-refs.csv` (218 concrete + 82 appendix-page + 30 fuzzy = 330 rows; 4 anchor-needed concrete refs in `index.qmd` are pre-existing per #295 follow-up).
- [ ] CI green on this PR (no false positives).
- [ ] Negative test (later, separate PR or manual): introduce a deliberate `Day 99 page 99` somewhere → confirm job fails with the run-locally hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)