### PR TITLE
Housekeeping: gitignore Quarto's root-level *_files/ artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ _freeze/
 
 # Quarto per-page library bundles (created next to rendered .qmd files)
 content/**/*_files/
+/*_files/
 
 node_modules/
 


### PR DESCRIPTION
## Summary
- Extends `.gitignore` to cover Quarto's per-page supporting-assets directory when emitted next to a root-level `.qmd` (e.g. `index_files/` from `quarto render index.qmd`).
- Existing pattern `content/**/*_files/` only catches per-day chapter renders; root-level surfaces (`index.qmd`, `welcome.qmd`, etc.) leaked through.

## Test plan
- [x] `git status` shows no untracked `index_files/` after this change.
- [x] Existing `content/**/*_files/` rule unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)