### PR TITLE
Site: record Neave's public-release blessing + enable sitemap/footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Each day includes:
 
 ## 📥 Accessing the Course Material
 
-### Interactive Online Version (Work in Progress)
+### Interactive Online Version
 - **Live Course**: [deming.leedurbin.co.nz](https://deming.leedurbin.co.nz) - The interactive version with embedded activities and exercises
 
-**Current Status**: All 12 days are now fully converted from the original PDF format into the interactive experience. Content refinements, accessibility improvements, and activity polish are ongoing.
+**Current Status**: All 12 days are fully converted from the original PDF format into the interactive experience. Dr Henry Neave reviewed this edition and, in May 2026, gave his blessing for it to be made publicly available. Accessibility improvements and activity refinements are ongoing.
 
 **Enhanced Features in the Online Version:**
 - **Interactive Clock Indicators**: Built-in timing guidance to help you pace your study sessions
@@ -168,9 +168,9 @@ This course has benefited from contributions from many experts and practitioners
 
 All 12 days have been converted from Neave's source PDFs into interactive Quarto chapters. For ongoing edits, see [`workflow/PATTERNS.md`](workflow/PATTERNS.md) — the house-style reference covering CSS classes, R functions, interactive element templates, accessibility conventions, and inter-day cross-reference rules. The original 5-phase conversion workflow is archived at [`workflow/archive/CONVERSION_PROCESS.md`](workflow/archive/CONVERSION_PROCESS.md) for traceability.
 
-## 📄 License
+## 📄 License and Permissions
 
-This course is based on Dr. W. Edwards Deming's teachings and is made available for educational purposes. Please respect the intellectual property and use appropriately.
+The course content is reproduced with the explicit permission of its author, Dr Henry R. Neave, who reviewed this digital edition and authorised its public release in May 2026. The original "12 Days to Deming" materials remain freely available as PDFs from the [New Zealand Organisation for Quality (NZOQ)](https://www.nzoq.org.nz/12-days-to-deming) and other quality organisations. This interactive edition is non-commercial and is offered for educational use; please credit Dr Neave when sharing or quoting the material.
 
 ## 🌐 Live Version
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -23,7 +23,7 @@ book:
     left: |
       Course content © Dr Henry R. Neave. Reproduced with permission (May 2026).
     right: |
-      Web edition by [Lee Durbin](https://leedurbin.co.nz) · [Source on GitHub](https://github.com/lddurbin/twelve_days_to_deming)
+      Web edition by [Lee Durbin](https://leedurbin.co.nz) <span aria-hidden="true">·</span> [Source on GitHub](https://github.com/lddurbin/twelve_days_to_deming)
   
   chapters:
     - about-this-edition.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -15,9 +15,15 @@ book:
   title: "12 Days to Deming"
   subtitle: "An active-learning course"
   author: "Henry R. Neave"
+  site-url: https://deming.leedurbin.co.nz
   reader-mode: true
   sidebar:
     collapse-level: 1
+  page-footer:
+    left: |
+      Course content © Dr Henry R. Neave. Reproduced with permission (May 2026).
+    right: |
+      Web edition by [Lee Durbin](https://leedurbin.co.nz) · [Source on GitHub](https://github.com/lddurbin/twelve_days_to_deming)
   
   chapters:
     - about-this-edition.qmd

--- a/about-this-edition.qmd
+++ b/about-this-edition.qmd
@@ -23,6 +23,12 @@ The full course material is available as free PDF downloads from several sources
 
 The [accessibility page](accessibility.qmd) catalogues the features currently in place — skip-to-content links, an OpenDyslexic font toggle, visible focus indicators, ARIA labelling, non-colour status cues, reduced-motion support, and print-safe styling — and lists the improvements still to come. If you encounter an accessibility issue, please email me directly at [hello@leedurbin.co.nz](mailto:hello@leedurbin.co.nz) and I'll be happy to explore how to improve the site.
 
+## Dr Neave's blessing
+
+When I began this project I shared early drafts privately, and I did not want to publish the site widely without Dr Neave's approval. Through Richard Hamilton, Dr Neave reviewed the live site in May 2026 and gave his blessing for it to be made publicly available. His words: *"do make it as publicly available as possible and hopefully many thousands of people will also soon be clicking that link!"*
+
+That endorsement matters to me for two reasons. First, it confirms that the adaptation is faithful to what he wrote — Dr Neave told Richard the experience was "thrilling" and that re-reading the material felt "almost like reading something I'd never seen before", which I take as a quiet vote of confidence in the transcription. Second, it means the accessibility-focused framing — a digital edition shaped around the needs of neuro-divergent and dyslexic learners — has the explicit support of the author of the original course.
+
 ## What has changed, and what hasn't
 
 In adapting 12 Days to Deming for the web, several adaptations were made. 


### PR DESCRIPTION
## Summary

Dr Henry Neave reviewed the live site in May 2026 and explicitly authorised it to be made publicly available. This PR records the endorsement in user-facing copy and shifts the site's posture from *private with permission to transcribe* to *publicly endorsed by the author*.

- **`about-this-edition.qmd`** — new `## Dr Neave's blessing` section, placed between *Why this edition exists* and *What has changed, and what hasn't*. Quotes Neave directly (*"do make it as publicly available as possible…"*) and explains what the endorsement covers: faithful transcription and the accessibility framing.
- **`README.md`** — drops the "(Work in Progress)" tag on the Live Course entry and replaces the generic `## 📄 License` blurb with a specific `## 📄 License and Permissions` section that credits Neave, points upstream to the NZOQ PDFs, and asks for citation when sharing.
- **`_quarto.yml`** — sets `book.site-url: https://deming.leedurbin.co.nz`, which causes Quarto to auto-generate `sitemap.xml` (with absolute URLs and lastmod timestamps) and `robots.txt` (no `Disallow` directives → fully indexable). Adds a `page-footer` with left/right slots: course content attribution to Neave on the left, web-edition credit + GitHub source link on the right.

## Why this matters

Until now the site has been deliberately low-profile pending Neave's approval. With his blessing in hand, the discoverability posture should match: search engines need a sitemap to index efficiently, and every page should carry persistent attribution so the provenance is unambiguous to readers and re-publishers.

## Test plan

- [x] `quarto render` completes clean across all 121 files
- [x] `_book/sitemap.xml` generated with absolute URLs + lastmod timestamps
- [x] `_book/robots.txt` generated with sitemap reference and no Disallow rules
- [x] Footer renders on `about-this-edition.html` with `nav-footer-left` / `nav-footer-right` classes (theme-aware styling via existing CSS)
- [x] `ruby -ryaml` validates `_quarto.yml` syntax
- [ ] Visual spot-check after deploy: footer layout on mobile, dark mode footer contrast, sitemap accessible at `/sitemap.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)