### PR TITLE
fix: even box spacing in Day 3.03 stacked-boxes histogram

### DIFF
--- a/R/functions/main-functions.R
+++ b/R/functions/main-functions.R
@@ -560,22 +560,27 @@ histogram_plot <- function(values,
 #' individual observations are before the gaps are filled in to make a
 #' conventional bar histogram in the right-hand panel).
 #'
-#' Uses \code{geom_point(shape = 22)} so the squares stay square regardless
-#' of the panel's aspect ratio (true square shapes are sized in millimetres,
-#' not data units — \code{geom_tile} would only look square when the data
-#' aspect matches the panel aspect).
+#' Uses \code{geom_tile} with \code{coord_fixed(ratio = 1)} so the tile size
+#' AND the gap between adjacent tiles are both expressed in data units —
+#' this keeps the gap-to-box ratio constant horizontally and vertically
+#' regardless of the panel's aspect ratio. An earlier version used
+#' \code{geom_point(shape = 22)} sized in millimetres, but that left
+#' visible asymmetric gaps (large vertical, small horizontal) whenever the
+#' panel was wider than tall.
 #'
 #' @param values Numeric vector. Integer-like observations to stack.
 #' @param x_breaks Numeric vector or NULL. Major x-axis tick positions.
 #'   If NULL, ggplot picks the breaks via its default heuristic.
-#' @param box_size Numeric. Square edge length in mm (passed as the
-#'   \code{size} argument to \code{geom_point}). Default 12; reduce if the
-#'   tallest stack starts touching the chart top.
+#' @param box_fill Numeric in (0, 1]. Fraction of the unit cell each box
+#'   occupies; the remainder shows as the gap between adjacent boxes.
+#'   Default 0.85 — a small but visible gap on every side, matching
+#'   Neave's printed page-7 figure.
 #' @return A ggplot2 object.
 #' @examples
 #' stacked_boxes_plot(c(10, 11, 11, 11, 12, 12), x_breaks = 10:12)
-stacked_boxes_plot <- function(values, x_breaks = NULL, box_size = 12) {
-  stopifnot(is.numeric(values), length(values) >= 1)
+stacked_boxes_plot <- function(values, x_breaks = NULL, box_fill = 0.85) {
+  stopifnot(is.numeric(values), length(values) >= 1,
+            box_fill > 0, box_fill <= 1)
 
   df <- data.frame(value = values) |>
     dplyr::group_by(.data$value) |>
@@ -585,8 +590,9 @@ stacked_boxes_plot <- function(values, x_breaks = NULL, box_size = 12) {
   max_stack <- max(df$stack)
 
   p <- ggplot(df, aes(x = .data$value, y = .data$stack)) +
-    geom_point(shape = 22, size = box_size,
-               fill = CHART_LINE_COLOUR, colour = CHART_FG, stroke = 0.4)
+    geom_tile(width = box_fill, height = box_fill,
+              fill = CHART_LINE_COLOUR, colour = CHART_FG, linewidth = 0.4) +
+    coord_fixed(ratio = 1, clip = "off")
 
   if (!is.null(x_breaks)) {
     p <- p + scale_x_continuous(breaks = x_breaks)

--- a/content/days/day-03/03-the-importance-of-time.qmd
+++ b/content/days/day-03/03-the-importance-of-time.qmd
@@ -13,7 +13,7 @@ Here are two forms of histogram of those data. On the left, each item in the dat
 
 ```{r two-histograms-24-values, fig.width=10, fig.height=4, fig.align="center", fig.cap="Two histograms of the same 24 values ranging from 10 to 19: on the left, individual boxes stacked to show frequency, with small visible gaps between adjacent boxes; on the right, a conventional bar histogram with the gaps filled in. Both peak at 13 with five occurrences and tail off toward 10 and 19."}
 first_process <- read.csv("../../../R/data/day-03-first-process.csv", comment.char = "#")$value
-left  <- stacked_boxes_plot(first_process, x_breaks = 10:19, box_size = 14)
+left  <- stacked_boxes_plot(first_process, x_breaks = 10:19)
 right <- histogram_plot(first_process, binwidth = 1, boundary = 9.5,
                        x_breaks = 10:19) +
   theme(axis.text.y        = element_blank(),


### PR DESCRIPTION
## Summary

- Switches `stacked_boxes_plot()` from `geom_point(shape = 22)` sized in mm to `geom_tile()` sized in data units, with `coord_fixed(ratio = 1)` to keep the tiles literally square on screen.
- With the old mm-sized geom, the gap between adjacent boxes was governed by the panel's data-units-per-mm — which differs on the two axes whenever the panel isn't square. The Day 3.03 figure (10in × 4in panel) ended up with small horizontal gaps but oversized vertical gaps.
- After the switch, both gaps are exactly `1 - box_fill = 0.15` data units regardless of panel aspect, matching Neave's printed page-7 layout.
- The `box_size` parameter (in mm) is replaced by `box_fill` (fraction of unit cell); default 0.85. The single call site in [Day 3.03](content/days/day-03/03-the-importance-of-time.qmd) drops the override and uses the default.

## Test plan

- [x] `quarto render content/days/day-03/03-the-importance-of-time.qmd` — renders cleanly; box panel now tightly stacked with even gaps in both directions.
- [x] `coord_fixed` makes the box panel naturally narrower than the bar histogram in the `wrap_plots(left, right)` side-by-side — matches Neave's printed page-7 layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)