### PR TITLE
ci: add merge_group triggers to enable GitHub merge queue (#385)

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -6,6 +6,9 @@ permissions:
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,10 +3,20 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+  # Merge queue: the queue may include this workflow's job in its required
+  # checks list, so the workflow must report a status on queue branches.
+  # The job below is gated to pull_request events because the review prompt
+  # interpolates github.event.pull_request.number — undefined on merge_group
+  # events — and reviewing the projected merge state adds no value over the
+  # review that already ran on the originating PR. On merge_group events the
+  # job is skipped, which GitHub reports as a neutral/passing required check.
+  merge_group:
+    branches:
+      - main
 
 jobs:
   claude-review:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/interday-audit.yml
+++ b/.github/workflows/interday-audit.yml
@@ -15,6 +15,14 @@ on:
       - 'scripts/build-interday-audit.R'
       - 'workflow/inter-day-refs.csv'
       - '.github/workflows/interday-audit.yml'
+  # Merge queue: GitHub creates an ephemeral gh-readonly-queue/main/<sha>
+  # branch and waits on required checks. We deliberately omit `paths` here so
+  # the queue gets a status report even when a queued PR doesn't itself touch
+  # the audit's input paths — without that, the queue can stall waiting for a
+  # check that the path filter suppressed.
+  merge_group:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -16,6 +16,14 @@ on:
       - 'assets/images/**'
       - 'scripts/check-structure.sh'
       - '.github/workflows/structure-check.yml'
+  # Merge queue: deliberately no `paths` filter here so the queue gets a
+  # status report on the gh-readonly-queue/main/<sha> branch even when a
+  # queued PR doesn't itself touch the structure-check input paths. Without
+  # this, the queue can stall waiting for a check that the path filter
+  # suppressed.
+  merge_group:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,15 @@ Reference cropped images in `.qmd` files:
 - **Production**: Deploys to `deming.leedurbin.co.nz`
 - **Build Environment**: Ubuntu with R, Quarto, and system dependencies
 - **Deploy Method**: rsync over SSH to production server
+
+## Merge workflow
+
+The `main` branch is protected by GitHub's merge queue. When merging an approved PR, use `--auto` so the queue handles serialisation:
+
+```
+gh pr merge <pr-number> --auto --squash --delete-branch
+```
+
+`--auto` enqueues the PR; GitHub then rebases each entry against the projected main (current main + everything queued ahead), runs CI on an ephemeral `gh-readonly-queue/main/<sha>` branch, and merges in order. No force-push, no rebase loop on PR branches, no full CI re-run for `BEHIND` updates. See issue [#385](https://github.com/lddurbin/twelve_days_to_deming/issues/385) for the rationale.
+
+CI workflows that gate the queue (`accessibility`, `claude-code-review`, `interday-audit`, `structure-check`) all fire on the `merge_group` event so they report status on queue branches.


### PR DESCRIPTION
## Summary
- Adds `merge_group` triggers to the four PR-gating workflows: `accessibility.yml`, `interday-audit.yml`, `structure-check.yml`, `claude-code-review.yml`.
- Documents the new merge command (`gh pr merge --auto --squash --delete-branch`) in `CLAUDE.md`.

Refs #385. **Enabling the queue itself is a separate manual step** in repo Settings → Rules → Rulesets after this PR lands.

## Per-workflow notes

| Workflow | Approach |
|---|---|
| `accessibility.yml` | Trigger added, job runs unconditionally on queue branches. |
| `interday-audit.yml` | Trigger added with **no `paths` filter** — paths filtering on `merge_group` events risks stalling the queue waiting for a check the filter suppressed. |
| `structure-check.yml` | Same as interday-audit — no `paths` filter on `merge_group`. |
| `claude-code-review.yml` | Trigger added, but the job is gated `if: github.event_name == 'pull_request'`. The review prompt interpolates `github.event.pull_request.number` (undefined on `merge_group`) and reviewing the projected merge state adds no value over the review that already ran on the PR. The job is skipped on queue branches, which GitHub reports as a neutral required check. |
| `link-check.yml` | **Intentionally not changed.** It's scheduled-only (Monday weekly cron) with no `pull_request` trigger, so it's not relevant to the merge queue. The issue lists it among the five workflows but it has nothing to gate. |

## Deviations from the issue spec

1. **`link-check.yml` not updated.** Reason above — it has no `pull_request` trigger to mirror, and adding `merge_group` would only run the slow weekly job against every queue group for zero gating value. Happy to add it back if you'd rather have the symmetry.
2. **`claude-code-review.yml` gated rather than fully running.** The workflow body can't function on `merge_group` events because it indexes `pull_request.number` and posts to a PR by number. Skipping the job is the safe behaviour. If the bot's status check needs to actually run on queue branches (rather than skip), the workflow body would need a separate code path for `merge_group` events.

## Catches to verify before enabling the queue

These are from the issue's own "Catches to verify" section, repeated here so they're not forgotten:

1. **Required-check name parity.** The job names produced by `merge_group` runs must match the required-check entries in branch protection / ruleset. The same workflow files produce both PR and queue runs, so names should match — confirm with one trial PR after enabling.
2. **`claude-review` skipped-as-passing.** GitHub generally treats skipped jobs as passing for required-status-check purposes, but the queue's behaviour with a skipped required check is worth verifying with a single trial PR. If the queue does stall, the fix is to remove `claude-review` from the required-check list in branch protection (it can still post advisory comments on PRs).
3. **Stitched deviations log conflict** is being addressed in #386 (closes #384). Ideally land #386 first so the queue never has to deal with the stitched-file conflict during the rollout window.

## Rollout (from the issue)

1. Land #386 (covers #384) so the queue isn't fighting the stitched-log artifact.
2. Land this PR.
3. Enable the queue in repo Settings → Rules → Rulesets for `main` (squash strategy, min group 1, max group 5, max wait 5 min, build concurrency 1).
4. Open one trial PR (a docs change is fine) to confirm the queue processes it end-to-end.

## Test plan
- [x] YAML syntax validates on all 5 workflow files.
- [ ] CI green on this PR (existing `pull_request` trigger paths still work).
- [ ] After merge + enabling the queue: one trial PR confirms required checks report green on a queue-branch run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)