### PR TITLE
fix(tests): restore CoordCartesian assertion for radar diagram

### DIFF
--- a/tests/testthat/test-radar-diagram.R
+++ b/tests/testthat/test-radar-diagram.R
@@ -25,6 +25,9 @@ test_that("radar_diagram_plot labels all four arms", {
 
 test_that("radar_diagram_plot uses a fixed-aspect coordinate system", {
   p <- radar_diagram_plot()
-  expect_s3_class(p$coordinates, "CoordFixed")
+  # ggplot2 4.0 collapsed CoordFixed into CoordCartesian; the surviving
+  # signal that this is coord_fixed() and not coord_cartesian() is a
+  # non-null ratio (coord_cartesian leaves ratio NULL).
+  expect_s3_class(p$coordinates, "CoordCartesian")
   expect_equal(p$coordinates$ratio, 1)
 })


### PR DESCRIPTION
## Summary

- Reverts the test assertion on `radar_diagram_plot()`'s coord class from `CoordFixed` back to `CoordCartesian` — the change introduced in [b3d2221](https://github.com/lddurbin/twelve_days_to_deming/commit/b3d2221) (PR #381 follow-up) was based on a false premise about ggplot2's class hierarchy.
- Has been failing every `Build and Deploy` run on main since #381 merged ([example](https://github.com/lddurbin/twelve_days_to_deming/actions/runs/26538550934)).

## Why the old assertion was already correct

In ggplot2 4.0.x, `coord_fixed()` does **not** return an object inheriting from `CoordFixed`. It returns a plain `CoordCartesian` whose only distinguishing trait is a non-null `$ratio`. Verified locally:

```r
> p1 <- ggplot() + coord_cartesian(); class(p1$coordinates)
[1] "CoordCartesian" "Coord" "ggproto" "gg"
> p1$coordinates$ratio
NULL

> p2 <- ggplot() + coord_fixed(); class(p2$coordinates)
[1] "CoordCartesian" "Coord" "ggproto" "gg"
> p2$coordinates$ratio
[1] 1
```

So `expect_s3_class(p$coordinates, "CoordCartesian")` paired with `expect_equal(p$coordinates$ratio, 1)` already rules out `coord_cartesian()` (its ratio is `NULL`) — the ratio assertion is the discriminator, not the class.

The reviewer feedback that prompted #381's tightening was given in good faith but assumed an older ggplot2 class hierarchy that no longer exists. Added a comment in the test so the next reviewer doesn't propose the same change.

## Test plan

- [x] `Rscript -e 'testthat::test_file("tests/testthat/test-radar-diagram.R")'` → all 4 pass locally
- [x] `Rscript -e 'testthat::test_dir("tests/testthat")'` → 93 PASS, 0 FAIL
- [ ] CI `Build and Deploy` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)