### PR TITLE
feat(quarto): add _quarto-fr.yml profile for French build

### DIFF
--- a/_quarto-fr.yml
+++ b/_quarto-fr.yml
@@ -1,0 +1,9 @@
+lang: fr
+
+project:
+  output-dir: _book/fr
+
+book:
+  chapters:
+    - content-fr/welcome.qmd
+  appendices: []


### PR DESCRIPTION
## Summary

Adds the Quarto profile file activated by `quarto render --profile fr`, per the architectural decision in #320 (Option A). The profile is intentionally minimal — overrides only `lang`, `project.output-dir`, `book.chapters`, and `book.appendices`; everything else (theme, CSP header-includes, page-footer, filters, format settings) inherits from `_quarto.yml`.

The chapter list references `content-fr/welcome.qmd`, which is added by the parallel PR for #394. Until that lands, `quarto render --profile fr` will error on the missing source — expected at this stage of the scaffold. The CI deploy workflow is not modified here; FR rendering is wired into CI by the later #396 PR.

## Test plan

- [x] YAML parses (validated via `ruby -ryaml`).
- [x] `_quarto.yml` untouched (no EN regression possible from this PR alone).
- [x] Profile overrides only what differs; no theme/CSP/filter redeclaration.
- [ ] Once #394 merges: `quarto render --profile fr` produces `_book/fr/welcome.html`.

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)