### PR TITLE
feat(content-fr): add stub welcome chapter for French edition

### DIFF
--- a/content-fr/welcome.qmd
+++ b/content-fr/welcome.qmd
@@ -1,0 +1,7 @@
+---
+title: "Bienvenue"
+execute:
+  echo: false
+---
+
+L'édition française du cours *12 jours pour Deming* est en cours de préparation. Cette page sera remplacée par la traduction de la page d'accueil dans une mise à jour ultérieure.


### PR DESCRIPTION
## Summary

Creates the `content-fr/` root and adds one stub `welcome.qmd` so the FR profile (#399, the PR for #393) has a valid chapter target. Mirrors the EN tree at the same relative path, per Option A in #320.

The stub body is intentionally one paragraph of natural French — the page is a translation-pipeline placeholder, not the actual translated welcome. The real translation will replace it later in the pipeline (#329, #332).

**Why no explicit `{#sec-…}` IDs:** The EN sibling [`welcome.qmd`](https://github.com/lddurbin/twelve_days_to_deming/blob/main/welcome.qmd) carries no explicit section IDs (Quarto auto-generates from heading text). Adding IDs only on the FR side would create exactly the EN/FR divergence the architecture doc warns against. Cross-reference ID parity becomes meaningful once translated content lands and `@sec-…` references start targeting these pages; a future refactor can add explicit IDs to both sides together.

## Test plan

- [x] `content-fr/welcome.qmd` exists with stub French content.
- [x] EN build is unaffected (only new files added; `_quarto.yml` untouched).
- [x] Mirrors the EN path structure as required by #320.
- [ ] Once #399 (the `_quarto-fr.yml` profile PR) merges: `quarto render --profile fr` produces `_book/fr/welcome.html`.

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)