### PR TITLE
ci: wire FR render into deploy, gated behind DEPLOY_FR, + PR build-check (#396)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,8 +113,15 @@ jobs:
           ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-
           ${{ runner.os }}-freeze-
 
-    - name: Build Quarto book
+    - name: Build Quarto book (EN)
       run: quarto render
+
+    # FR must render AFTER EN: Quarto cleans its output-dir before each render,
+    # and the FR output-dir (_book/fr) is nested inside EN's (_book). Rendering
+    # EN second would wipe the FR tree. This produces the merged _book/{,fr/}
+    # tree the single rsync below ships. Drop this step to revert to EN-only.
+    - name: Build Quarto book (FR)
+      run: quarto render --profile fr
 
     - name: Smoke test build output
       run: |
@@ -134,6 +141,28 @@ jobs:
           day=$(basename "$day_dir" | sed 's/day-//')
           ls _book/content/days/day-${day}/*.html > /dev/null 2>&1 || { echo "FAIL: No HTML files for day-${day}"; exit 1; }
           echo "  day-${day}: OK"
+        done
+
+        echo "Checking FR build output..."
+        # FR entry page is a Quarto-generated index.html that redirects to
+        # index.fr.html (the first chapter is index.fr.qmd). Asserting index.html
+        # both gates the deploy and verifies the redirect shim shipped.
+        test -f _book/fr/index.html || { echo "FAIL: _book/fr/index.html missing"; exit 1; }
+
+        # FR content lives in content-fr/ and renders to _book/fr/content-fr/.
+        # FR_CONTENT_GLOBS is the generalization point: today FR has only the
+        # stub welcome page, so adding FR day content later is a one-line glob
+        # addition (e.g. "content-fr/days/day-*/*.qmd"), not a workflow refactor.
+        FR_CONTENT_GLOBS=(
+          "content-fr/*.qmd"
+        )
+        for glob in "${FR_CONTENT_GLOBS[@]}"; do
+          for src in $glob; do
+            [ -e "$src" ] || continue
+            html="_book/fr/${src%.qmd}.html"
+            test -f "$html" || { echo "FAIL: missing FR HTML $html (from $src)"; exit 1; }
+            echo "  ${src}: OK"
+          done
         done
 
         echo "Smoke test passed"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,11 +119,20 @@ jobs:
     # FR must render AFTER EN: Quarto cleans its output-dir before each render,
     # and the FR output-dir (_book/fr) is nested inside EN's (_book). Rendering
     # EN second would wipe the FR tree. This produces the merged _book/{,fr/}
-    # tree the single rsync below ships. Drop this step to revert to EN-only.
+    # tree the single rsync below ships.
+    #
+    # Gated on the DEPLOY_FR repo variable (Settings → Variables), default off.
+    # While the French edition is built incrementally on main, this stays off so
+    # partial FR never reaches production — every merge re-deploys EN only. Flip
+    # DEPLOY_FR to 'true' on launch day to ship the complete FR edition at /fr/;
+    # flip back to roll the launch back. No code change needed either way.
     - name: Build Quarto book (FR)
+      if: vars.DEPLOY_FR == 'true'
       run: quarto render --profile fr
 
     - name: Smoke test build output
+      env:
+        DEPLOY_FR: ${{ vars.DEPLOY_FR }}
       run: |
         echo "Checking index.html exists..."
         test -f _book/index.html || { echo "FAIL: _book/index.html missing"; exit 1; }
@@ -143,27 +152,34 @@ jobs:
           echo "  day-${day}: OK"
         done
 
-        echo "Checking FR build output..."
-        # FR entry page is a Quarto-generated index.html that redirects to
-        # index.fr.html (the first chapter is index.fr.qmd). Asserting index.html
-        # both gates the deploy and verifies the redirect shim shipped.
-        test -f _book/fr/index.html || { echo "FAIL: _book/fr/index.html missing"; exit 1; }
+        # FR assertions only apply when DEPLOY_FR is on (matching the gated FR
+        # render step above). While FR is off, _book/fr is never produced and
+        # asserting it would fail the EN-only deploy.
+        if [ "$DEPLOY_FR" = "true" ]; then
+          echo "Checking FR build output..."
+          # FR entry page is a Quarto-generated index.html that redirects to
+          # index.fr.html (the first chapter is index.fr.qmd). Asserting
+          # index.html both gates the deploy and verifies the redirect shipped.
+          test -f _book/fr/index.html || { echo "FAIL: _book/fr/index.html missing"; exit 1; }
 
-        # FR content lives in content-fr/ and renders to _book/fr/content-fr/.
-        # FR_CONTENT_GLOBS is the generalization point: today FR has only the
-        # stub welcome page, so adding FR day content later is a one-line glob
-        # addition (e.g. "content-fr/days/day-*/*.qmd"), not a workflow refactor.
-        FR_CONTENT_GLOBS=(
-          "content-fr/*.qmd"
-        )
-        for glob in "${FR_CONTENT_GLOBS[@]}"; do
-          for src in $glob; do
-            [ -e "$src" ] || continue
-            html="_book/fr/${src%.qmd}.html"
-            test -f "$html" || { echo "FAIL: missing FR HTML $html (from $src)"; exit 1; }
-            echo "  ${src}: OK"
+          # FR content lives in content-fr/ and renders to _book/fr/content-fr/.
+          # FR_CONTENT_GLOBS is the generalization point: today FR has only the
+          # stub welcome page, so adding FR day content later is a one-line glob
+          # addition (e.g. "content-fr/days/day-*/*.qmd"), not a workflow refactor.
+          FR_CONTENT_GLOBS=(
+            "content-fr/*.qmd"
+          )
+          for glob in "${FR_CONTENT_GLOBS[@]}"; do
+            for src in $glob; do
+              [ -e "$src" ] || continue
+              html="_book/fr/${src%.qmd}.html"
+              test -f "$html" || { echo "FAIL: missing FR HTML $html (from $src)"; exit 1; }
+              echo "  ${src}: OK"
+            done
           done
-        done
+        else
+          echo "DEPLOY_FR not 'true' — skipping FR assertions (EN-only deploy)"
+        fi
 
         echo "Smoke test passed"
 

--- a/.github/workflows/fr-build-check.yml
+++ b/.github/workflows/fr-build-check.yml
@@ -1,0 +1,130 @@
+name: FR Build Check
+
+permissions:
+  contents: read
+
+# Build-only validation of the French profile. This NEVER deploys — it exists
+# so FR breakage surfaces on the PR that causes it, rather than on launch day
+# when DEPLOY_FR is flipped on in deploy.yml. Path-filtered to FR-affecting
+# files so unrelated PRs don't run it.
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'content-fr/**'
+      - 'index.fr.qmd'
+      - '_quarto-fr.yml'
+      - '_quarto.yml'
+      - '.github/workflows/fr-build-check.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Opt r-lib/actions into Node 24 ahead of the Sept 2026 Node 20 removal.
+# Remove once r-lib publishes a v3 tag that runs on Node 24 natively.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  render-fr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+    - name: Setup R
+      id: setup-r
+      uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e  # v2
+      with:
+        r-version: '4.5.1'
+        use-public-rspm: true
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libcurl4-openssl-dev \
+          libssl-dev \
+          libxml2-dev \
+          libpng-dev \
+          libjpeg-dev \
+          libcairo2-dev \
+          libfontconfig1-dev \
+          libfreetype6-dev \
+          build-essential \
+          gfortran \
+          libgmp3-dev \
+          libglpk-dev
+
+    - name: Setup Pandoc
+      uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e  # v2
+      with:
+        pandoc-version: '3.1.11'
+
+    - name: Cache Quarto installation
+      id: cache-quarto
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: /opt/quarto
+        key: quarto-1.4.549
+
+    - name: Install Quarto
+      if: steps.cache-quarto.outputs.cache-hit != 'true'
+      run: |
+        curl -LO https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.549/quarto-1.4.549-linux-amd64.deb
+        sudo dpkg -i quarto-1.4.549-linux-amd64.deb
+
+    - name: Add Quarto to PATH
+      run: echo "/opt/quarto/bin" >> $GITHUB_PATH
+
+    - name: Cache R packages
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: ~/.cache/R/renv
+        key: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-${{ hashFiles('renv.lock') }}
+        restore-keys: ${{ runner.os }}-r${{ steps.setup-r.outputs.installed-r-version }}-renv-
+
+    - name: Restore R packages
+      shell: Rscript {0}
+      run: |
+        if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+        renv::restore()
+
+    # Same freeze cache scheme as deploy.yml: Quarto keys frozen outputs per
+    # source path, so FR sources at content-fr/... seed their own
+    # _freeze/content-fr/... entries here and reuse them on later runs.
+    - name: Cache Quarto freeze outputs
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      with:
+        path: _freeze
+        key: ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-
+          ${{ runner.os }}-freeze-
+
+    - name: Render FR profile (build-only, no deploy)
+      run: quarto render --profile fr
+
+    - name: Smoke test FR output
+      run: |
+        echo "Checking FR entry page..."
+        test -f _book/fr/index.html || { echo "FAIL: _book/fr/index.html missing"; exit 1; }
+
+        # Mirrors the FR assertion in deploy.yml. Adding FR day content later is
+        # a one-line glob addition here and in deploy.yml.
+        FR_CONTENT_GLOBS=(
+          "content-fr/*.qmd"
+        )
+        for glob in "${FR_CONTENT_GLOBS[@]}"; do
+          for src in $glob; do
+            [ -e "$src" ] || continue
+            html="_book/fr/${src%.qmd}.html"
+            test -f "$html" || { echo "FAIL: missing FR HTML $html (from $src)"; exit 1; }
+            echo "  ${src}: OK"
+          done
+        done
+
+        echo "FR build check passed"


### PR DESCRIPTION
Closes #396.

Wires the French edition into CI, but **gated off by default** so the incremental FR build never drips partial content to production. FR launch is a one-flag flip, not a stream of partial deploys.

## Why gated (scope note vs the original #396)

#396 as written assumed both renders always run and the FR smoke assertions always fire. During review we decided FR should **launch complete**, not accumulate in production page-by-page. Since FR is physically isolated (`content-fr/`, `_quarto-fr.yml`, `index.fr.qmd`) and the EN production render never reads those paths, the *only* thing that puts FR in prod is the second render step — so gating that one step gates the whole launch. The #396 machinery (render command, smoke shape, generalizable assertion) is all here; it's just opt-in.

## Changes

**`deploy.yml`**
- Add `quarto render --profile fr` immediately after the EN render — **gated on `if: vars.DEPLOY_FR == 'true'`** (repo variable, Settings → Variables, default off).
- FR smoke assertions (`_book/fr/index.html` + a generalizable `FR_CONTENT_GLOBS` loop) wrapped in the same `DEPLOY_FR` gate. EN assertions unchanged.
- rsync line and `_freeze` cache step untouched.

**`fr-build-check.yml` (new)**
- PR-only, path-filtered (`content-fr/**`, `index.fr.qmd`, `_quarto-fr.yml`, `_quarto.yml`) workflow that renders `--profile fr` **build-only, never deploys**, so FR breakage surfaces on the PR that causes it instead of on launch day.
- Same pinned action SHAs, R/Quarto/Pandoc versions, `_freeze` cache scheme, and `concurrency: cancel-in-progress` as the existing workflows.

## How the lifecycle works

| Phase | `DEPLOY_FR` | What ships to prod | FR validated by |
|-------|-------------|--------------------|-----------------|
| FR development | off (default) | EN only | `fr-build-check.yml` on each FR PR |
| Launch | flip to `true` | EN + complete FR at `/fr/` | deploy smoke test |
| Rollback | flip back to `false` | EN only | — |

No code change needed to launch or roll back.

## `_freeze/` cache verification (per #396 AC)

No cache-key change; none made. The key is `${{ runner.os }}-freeze-${{ hashFiles('renv.lock') }}-${{ github.sha }}` with `renv.lock`+SHA and broader restore-key fallbacks, caching the whole `_freeze/` directory. Quarto keys frozen outputs per source path, so FR sources under `content-fr/...` seed their own `_freeze/content-fr/...` entries — captured by the same cache step in both `fr-build-check.yml` (during dev) and `deploy.yml` (at launch). EN entries (`_freeze/content/days/...`) are at distinct paths and unaffected, so EN cache hit rate is unchanged.

## Triggers / merge_group note

`deploy.yml` triggers on `push`-to-`main` + `workflow_dispatch` only — it's the deploy-to-prod job, not a merge-queue gate, so it intentionally has no `merge_group` trigger. Triggers unchanged by this PR. The new `fr-build-check.yml` runs on `pull_request` + `workflow_dispatch`; it doesn't gate the (org-only, currently inert) merge queue.

## Note on GitHub Actions cost

This repo is **public**, so Actions minutes are free/unlimited on standard runners — the second workflow adds no billable cost. The path filters + concurrency cancellation are for latency/tidiness, and so FR renders only run when FR-affecting files change.

## Local verification

- Both workflow files validated as well-formed YAML.
- FR smoke + gate logic dry-run under `bash` (CI's shell): `DEPLOY_FR` unset/`false` → FR skipped (EN-only); `true` → FR asserted. Path mapping `content-fr/welcome.qmd` → `_book/fr/content-fr/welcome.html` confirmed, and the negative case (missing HTML) fails the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)