### PR TITLE
feat(prefs): add in-app feedback link + fix README clock bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ Each day includes:
 **Current Status**: All 12 days are fully converted from the original PDF format into the interactive experience. Dr Henry Neave reviewed this edition and, in May 2026, gave his blessing for it to be made publicly available. Accessibility improvements and activity refinements are ongoing.
 
 **Enhanced Features in the Online Version:**
-- **Interactive Clock Indicators**: Built-in timing guidance to help you pace your study sessions
+- **Reading-Time Estimates**: Each chapter shows an estimated reading time and, where Dr. Neave's source provides it, his recommended session time
 - **Embedded Activities**: Interactive exercises and reflections integrated directly into the reading flow
 - **In-page Text Inputs**: Capture your reflections, answers, and notes directly in the browser — this edition's substitute for the printable Workbook from the NZOQ PDF version
 - **Progress Tracking**: Visual indicators to help you monitor your advancement through the material
 - **Responsive Design**: Optimized for desktop, tablet, and mobile devices
 - **Search and Navigation**: Easy content discovery and cross-referencing
+- **In-app Feedback**: A "Send email" link in the preferences panel opens a pre-filled message (no account required), so readers can flag typos or suggestions on any page
 - **Print-Friendly**: Clean, formatted output for printing or PDF generation
 - **Accessibility**: Skip-link, reading-preferences panel (dark mode + dyslexia-friendly font), ARIA-labelled interactive elements, reduced-motion and high-contrast support — see the [Accessibility](#-accessibility) section below for the full list
 

--- a/assets/scripts/reading-prefs.js
+++ b/assets/scripts/reading-prefs.js
@@ -32,6 +32,22 @@
     }
   }
 
+  // mailto target for the feedback row. Built here (not in static HTML) and
+  // assembled from string fragments so the address never appears as a literal
+  // in the page source or the JS file — mild defence against scraper bots. A
+  // mailto has no endpoint, so it cannot be "submitted" by a bot; the only
+  // real risk is address harvesting, which this raises the bar against.
+  function feedbackHref() {
+    var addr = "hello" + "@" + "leedurbin.co.nz";
+    var subject = "12 Days to Deming — feedback";
+    var body =
+      "Your feedback (typos, confusing wording, accessibility issues, ideas):" +
+      "\n\n\n—\nSent from: " + document.title + "\n" + window.location.href;
+    return "mailto:" + addr +
+      "?subject=" + encodeURIComponent(subject) +
+      "&body=" + encodeURIComponent(body);
+  }
+
   function build(initialFont, initialDark) {
     var trigger = document.createElement("button");
     trigger.type = "button";
@@ -71,10 +87,21 @@
       '    <span class="reading-prefs-state" id="reading-prefs-font-state">' +
             (initialFont ? "On" : "Off") + '</span>' +
       '  </button>' +
+      '</div>' +
+      '<div class="reading-prefs-row">' +
+      '  <span class="reading-prefs-row-label" id="reading-prefs-feedback-label">Feedback</span>' +
+      '  <a class="reading-prefs-feedback-link"' +
+      '    aria-labelledby="reading-prefs-feedback-label reading-prefs-feedback-name">' +
+      '    <span class="reading-prefs-feedback-name" id="reading-prefs-feedback-name">Send email</span>' +
+      '    <span class="reading-prefs-feedback-arrow" aria-hidden="true">→</span>' +
+      '  </a>' +
       '</div>';
 
     document.body.appendChild(trigger);
     document.body.appendChild(panel);
+    // Set the mailto after insertion so the long encoded URL doesn't have to be
+    // escaped inside the innerHTML template above.
+    panel.querySelector(".reading-prefs-feedback-link").href = feedbackHref();
 
     var themeBtn = panel.querySelector('[data-pref="theme"]');
     var themeState = panel.querySelector("#reading-prefs-theme-state");

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -721,7 +721,8 @@ button:focus,
   .reading-prefs-panel {
     border-width: 3px;
   }
-  .reading-prefs-control {
+  .reading-prefs-control,
+  .reading-prefs-feedback-link {
     border-width: 2px;
   }
   .reading-prefs-control[aria-pressed="true"] {
@@ -1073,6 +1074,33 @@ button:focus,
   background-color: #262680;
 }
 
+/* Feedback row link inside the panel. Styled to match the toggle controls,
+   but it is a mailto navigation link rather than a toggle. */
+.reading-prefs-feedback-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #3333a6;
+  background-color: #fff;
+  border: 1px solid #3333a6;
+  border-radius: 4px;
+  text-decoration: none;
+}
+.reading-prefs-feedback-link:hover {
+  background-color: #e8e8f4;
+  text-decoration: none;
+}
+.reading-prefs-feedback-link:focus-visible {
+  outline: 3px solid #ffbf00;
+  outline-offset: 2px;
+}
+.reading-prefs-feedback-arrow {
+  font-weight: 700;
+}
 
 /* Hide Quarto's navbar dark-mode toggle: the panel is now the single
    reading-preferences entry point. The link still emits in HTML so its
@@ -1354,6 +1382,15 @@ body.quarto-dark .reading-prefs-control[aria-pressed="true"]:hover {
   background-color: #4040c0;
 }
 
+/* Feedback link: same dark palette as the reading-prefs controls. */
+body.quarto-dark .reading-prefs-feedback-link {
+  color: #b0b0e6;
+  background-color: #1a1a26;
+  border-color: #8fa8ff;
+}
+body.quarto-dark .reading-prefs-feedback-link:hover {
+  background-color: #2a2a3a;
+}
 
 /* Glossary terms: brighten the amber underline for legibility against
    the darkly #222 body. */
@@ -1435,7 +1472,8 @@ body.quarto-dark .cell-output-display img[src$=".svg"] {
   body.quarto-dark .reading-prefs-panel {
     border-color: #c8d4ff;
   }
-  body.quarto-dark .reading-prefs-control {
+  body.quarto-dark .reading-prefs-control,
+  body.quarto-dark .reading-prefs-feedback-link {
     border-color: #c8d4ff;
   }
 }


### PR DESCRIPTION
## Summary

Gives readers a low-friction way to send feedback, and corrects a stale README feature claim.

### Feedback mechanism (new)
- Adds a **Feedback → Send email** row to the reading-preferences panel (`reading-prefs.js`)
- Opens a `mailto:` with a pre-filled subject and a body carrying the **current page title + URL**, so feedback is contextual
- Routes to `hello@leedurbin.co.nz` — a controlled-domain address that can be filtered/rerouted if ever abused, keeping feedback out of personal mail
- **No account, no backend, no CSP change** — `mailto:` is a protocol navigation, unaffected by the site's `connect-src` policy that rules out embedded third-party forms

### Anti-spam posture
A `mailto:` has no endpoint, so bots can't "submit" through it — the only real risk is address harvesting. Mitigations:
- href is **built in JS at runtime** → address absent from static HTML (defeats most harvesters)
- address **assembled from string fragments** → no literal email string even in the JS file
- controlled-domain address → containment lever if it ever leaks

### README fixes
- "Interactive Clock Indicators" → **"Reading-Time Estimates"**: `create_clock()` is no longer used anywhere in the project (only documented in `workflow/PATTERNS.md`); the live timing feature is the static reading-time / `session_minutes` indicator
- Added a feature bullet for the new in-app feedback link

### Implementation notes
Reuses the panel's existing accessible disclosure pattern and the link styling/markup previously used by the removed language row (base + dark-mode + high-contrast variants). Panel title stays "Preferences" — a feedback action in a settings menu is a common pattern. No `docs/deviations-from-source.md` entry: this is site UI, not a departure from Neave's text.

## Test plan

Verified with a jsdom integration test exercising the real `reading-prefs.js` (load script → fire `DOMContentLoaded` → assert DOM). **14/14 checks passed**, covering:
- Panel injects with exactly 3 rows (Theme, Dyslexia font, Feedback)
- Feedback link is an `<a>` with a correct `mailto:hello@leedurbin.co.nz` href
- Body carries the page title + URL; subject is set
- `aria-labelledby` pairs label + name; arrow is `aria-hidden`
- No literal email string in the JS source
- Panel starts hidden and opens on trigger click

Manual checks for the reviewer / mer(browser):
- [ ] `quarto preview`, open the `Aa` panel → Feedback row visible
- [ ] Click **Send email** → mail client opens with pre-filled subject + page context
- [ ] Keyboard: Tab to the link, Enter → same
- [ ] Toggle dark mode → link stays legible
- [ ] View source → `hello@leedurbin.co.nz` does not appear in HTML
- [ ] CI: `pa11y` (Accessibility) + `claude-review` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)